### PR TITLE
Render post content prior to feed generation

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -27,13 +27,13 @@
 
   {% for post in site.posts %}
     <entry>
-      <title>{{ post.title | xml_escape }}</title>
+      <title>{{ post.title | markdownify | strip_html | strip_newlines | xml_escape }}</title>
       <link href="{{ url_base }}{{ post.url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.date | date_to_xmlschema }}</updated>
 
       <id>{{ url_base }}{{ post.id }}</id>
-      <content type="html">{{ post.content | xml_escape }}</content>
+      <content type="html">{{ post.content | markdownify | xml_escape }}</content>
 
       {% if post.author %}
         <author>
@@ -50,7 +50,7 @@
       {% endfor %}
 
       {% if post.excerpt %}
-        <summary>{{ post.excerpt | strip_html | strip_newlines | xml_escape }}</summary>
+        <summary>{{ post.excerpt | markdownify | strip_html | strip_newlines | xml_escape }}</summary>
       {% endif %}
     </entry>
   {% endfor %}

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,6 @@
 #! /bin/bash
 
+set -e
+
 bundle exec rspec
 gem build jekyll-feed.gemspec

--- a/spec/fixtures/_posts/2013-12-12-dec-the-second.md
+++ b/spec/fixtures/_posts/2013-12-12-dec-the-second.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-December the twelfth, actually.
+# December the twelfth, actually.

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -54,7 +54,7 @@ describe(Jekyll::JekyllFeed) do
   end
 
   it "converts markdown posts to HTML" do
-    expect(contents).to match /\<h1 id=\"decemeber-the-twelfth-actually\">/
+    expect(contents).to match /&lt;p&gt;March the second!&lt;\/p&gt;/
   end
 
   context "parsing" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -53,6 +53,10 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).to match /Line 1\nLine 2\nLine 3/
   end
 
+  it "converts markdown posts to HTML" do
+    expect(contents).to match /\<h1 id=\"decemeber-the-twelfth-actually\">/
+  end
+
   context "parsing" do
     let(:feed) { RSS::Parser.parse(contents) }
 


### PR DESCRIPTION
It appears, right now, `post.content` is still markdown at the time the feed is processed. Ideally, we'd want this to be HTML. 

@parkr is it even possible to get the Markdown content as a generator? (or would we need to reimplement the renderer to render it ourselves)?

Fixes https://github.com/jekyll/jekyll-feed/issues/38.