### PR TITLE
Use jekyll-last-modified-at for updated date

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "typhoeus", "~> 0.7"
   spec.add_development_dependency "nokogiri", "~> 1.6"
+  spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
 
 end

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -30,7 +30,11 @@
       <title>{{ post.title | markdownify | strip_html | strip_newlines | xml_escape }}</title>
       <link href="{{ post.url | prepend: url_base }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
-      <updated>{{ post.date | date_to_xmlschema }}</updated>
+      {% if post.last_modified_at %}
+        <updated>{{ post.last_modified_at | date_to_xmlschema }}</updated>
+      {% else %}
+        <updated>{{ post.date | date_to_xmlschema }}</updated>
+      {% endif %}
 
       <id>{{ post.id | prepend: url_base | xml_escape }}</id>
       <content type="html">{{ post.content | markdownify | xml_escape }}</content>

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,5 +1,8 @@
 timezone: UTC
 
+gems:
+  - jekyll-last-modified-at
+
 defaults:
   -
     scope:

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -57,6 +57,10 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).to match /&lt;p&gt;March the second!&lt;\/p&gt;/
   end
 
+  it "converts uses last_modified_at where available" do
+    expect(contents).to match /<updated>2015-05-12T13:27:59\+00:00<\/updated>/
+  end
+
   context "parsing" do
     let(:feed) { RSS::Parser.parse(contents) }
 


### PR DESCRIPTION
If installed, use [**jekyll-last-modified-at**](https://github.com/gjtorikian/jekyll-last-modified-at) for a post's updated date.

Fixes #26