### PR TITLE
Add xml:base attribute to the feed tag

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -4,12 +4,11 @@
 {% else %}
   {% assign url_base = site.github.url %}
 {% endif %}
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ url_base | xml_escape }}">
   <generator uri="http://jekyllrb.com" version="{{ jekyll.version }}">Jekyll</generator>
   <link href="{{ page.url | prepend: url_base }}" rel="self" type="application/atom+xml" />
   <link href="{{ url_base }}/" rel="alternate" type="text/html" />
   <updated>{{ site.time | date_to_xmlschema }}</updated>
-  <xml:base>{{ url_base | xml_escape }}/</xml:base>
   <id>{{ url_base | xml_escape }}/</id>
 
   {% if site.name %}

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -4,7 +4,7 @@
 {% else %}
   {% assign url_base = site.github.url %}
 {% endif %}
-<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ url_base | xml_escape }}">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <generator uri="http://jekyllrb.com" version="{{ jekyll.version }}">Jekyll</generator>
   <link href="{{ page.url | prepend: url_base }}" rel="self" type="application/atom+xml" />
   <link href="{{ url_base }}/" rel="alternate" type="text/html" />
@@ -33,7 +33,9 @@
       <updated>{{ post.date | date_to_xmlschema }}</updated>
 
       <id>{{ post.id | prepend: url_base | xml_escape }}</id>
-      <content type="html">{{ post.content | markdownify | xml_escape }}</content>
+      <content type="html" xml:base="{{ url_base | xml_escape }}">
+        {{ post.content | markdownify | xml_escape }}
+      </content>
 
       {% if post.author %}
         <author>

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -33,7 +33,7 @@
       <updated>{{ post.date | date_to_xmlschema }}</updated>
 
       <id>{{ post.id | prepend: url_base | xml_escape }}</id>
-      <content type="html" xml:base="{{ url_base | xml_escape }}">
+      <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">
         {{ post.content | markdownify | xml_escape }}
       </content>
 

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -9,6 +9,7 @@
   <link href="{{ page.url | prepend: url_base }}" rel="self" type="application/atom+xml" />
   <link href="{{ url_base }}/" rel="alternate" type="text/html" />
   <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <xml:base>{{ url_base | xml_escape }}/</xml:base>
   <id>{{ url_base | xml_escape }}/</id>
 
   {% if site.name %}

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -33,9 +33,7 @@
       <updated>{{ post.date | date_to_xmlschema }}</updated>
 
       <id>{{ post.id | prepend: url_base | xml_escape }}</id>
-      <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">
-        {{ post.content | markdownify | xml_escape }}
-      </content>
+      <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">{{ post.content | markdownify | xml_escape }}</content>
 
       {% if post.author %}
         <author>


### PR DESCRIPTION
Per @pathawks over in https://github.com/jekyll/jekyll-feed/pull/36#issuecomment-104422305, and per the Atom spec:

>  Any element defined by this specification MAY have an xml:base
   attribute [W3C.REC-xmlbase-20010627].  When xml:base is used in an
   Atom Document, it serves the function described in section 5.1.1 of
   [RFC3986], establishing the base URI (or IRI) for resolving any
   relative references found within the effective scope of the xml:base
   attribute.

I believe this fixes #22.

/cc @holman and @bkeepers, as this should finally fix [the question that started this all](https://twitter.com/holman/status/597777659288887296)