### PR TITLE
Use uri in all places

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -59,8 +59,8 @@
           {% if post.author.email %}
             <email>{{ post.author.email | xml_escape }}</email>
           {% endif %}
-          {% if post.author.url %}
-            <uri>{{ post.author.url | xml_escape }}</uri>
+          {% if post.author.uri %}
+            <uri>{{ post.author.uri | xml_escape }}</uri>
           {% endif %}
         </author>
       {% endif %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -54,7 +54,7 @@ describe(Jekyll::JekyllFeed) do
   end
 
   it "supports post author name as an object" do
-    expect(contents).to match /<author>\s*<name>Ben<\/name>\s*<email>ben@example.com<\/email>\s*<\/author>/
+    expect(contents).to match /<author>\s*<name>Ben<\/name>\s*<email>ben@example.com<\/email>\s*<uri>http:\/\/ben.balter.com<\/uri>\s*<\/author>/
   end
 
   it "supports post author name as a string" do


### PR DESCRIPTION
For `site.author` we used `uri`, but for `post.author` we used `url`. I personally like `url` better, it's less pretentious, but went with `uri` in all cases, to match the documentation.