### PR TITLE
Allow posts to override post.id

### DIFF
--- a/spec/fixtures/_posts/2015-05-22-id.md
+++ b/spec/fixtures/_posts/2015-05-22-id.md
@@ -1,0 +1,5 @@
+---
+id: "postID"
+---
+
+This post overrides the default id.

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -85,6 +85,11 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).not_to match /Liquid is not rendered\./
   end
 
+  it "allows posts to override the default post.id" do
+    expected = "<id>postID</id>"
+    expect(contents).to include(expected)
+  end
+
   context "parsing" do
     let(:feed) { RSS::Parser.parse(contents) }
 
@@ -105,9 +110,9 @@ describe(Jekyll::JekyllFeed) do
 
     it "includes the items" do
       if Gem::Version.new(Jekyll::VERSION) > Gem::Version.new('3')
-        expect(feed.items.count).to eql(8)
-      else
         expect(feed.items.count).to eql(9)
+      else
+        expect(feed.items.count).to eql(10)
       end
     end
 
@@ -125,9 +130,9 @@ describe(Jekyll::JekyllFeed) do
 
     it "doesn't include the item's excerpt if blank" do
       if Gem::Version.new(Jekyll::VERSION) > Gem::Version.new('3')
-        post = feed.items.first
-      else
         post = feed.items.fetch(1)
+      else
+        post = feed.items.fetch(2)
       end
       expect(post.summary).to be_nil
     end


### PR DESCRIPTION
This PR contains a failing test.

Apparently, it is not possible for a post to override it's Jekyll assigned `post.id`?