### PR TITLE
Fix Liquid error

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -35,7 +35,7 @@
     </author>
   {% endif %}
 
-  {% for post in site.posts | limit: 10 %}
+  {% for post in site.posts limit: 10 %}
     <entry>
       <title>{{ post.title | markdownify | strip_html | strip_newlines | xml_escape }}</title>
       <link href="{{ post.url | prepend: url_base }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />


### PR DESCRIPTION
According to the [Liquid docs](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#for-loops), we should not include a pipe before `limit`.

Fixes #48

We should also add a test that makes sure we are actually limiting to 10 posts. Right now, there just aren't that many posts in our test site. Should that be part of this PR, or another?