### PR TITLE
Loosen Jekyll Version Requirements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ mkmf.log
 Gemfile.lock
 spec/dest
 .bundle
+spec/fixtures/.jekyll-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vendor
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,13 @@ matrix:
   exclude:
     - rvm: 1.9
       env: JEKYLL_VERSION=3.0.0.beta5
+    - env: JEKYLL_VERSION=2.4
+      rvm: 2.1
+    - rvm: 2.2
+      env: JEKYLL_VERSION=2.4
 
 env:
   matrix:
     - ""
+    - JEKYLL_VERSION=2.4
     - JEKYLL_VERSION=3.0.0.beta5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,18 @@ rvm:
 - 2.1
 - 2.2
 - 2.0
-- 1.9.3
-before_script: bundle update
+- 1.9
 script: "script/cibuild"
-sudo: false
+before_script: bundle update
 cache: bundler
+sudo: false
+
+matrix:
+  exclude:
+    - rvm: 1.9
+      env: JEKYLL_VERSION=3.0.0.beta5
+
+env:
+  matrix:
+    - ""
+    - JEKYLL_VERSION=3.0.0.beta5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
 - 2.1
-- 2.0.0
+- 2.2
+- 2.0
 - 1.9.3
 before_script: bundle update
 script: "script/cibuild"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
-
 gemspec
+
+if ENV["JEKYLL_VERSION"]
+  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+end

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,12 +14,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", "~> 2.0"
+  spec.add_development_dependency "jekyll", ">= 2.5"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "typhoeus", "~> 0.7"
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
-
 end

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 2.5"
+  spec.add_development_dependency "jekyll", ">= 2.4.0", "< 3.1.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Currently we default install jekyll-feed across all our Docker images (master,beta included) and because of the tight coupling that happens on versioning we end up with multiple versions of Jekyll, this loosens that requirement since I don't assume this would break but if it does during this pull I'll gladly fix any problems so it works with both 2.5 and 3.0.