### PR TITLE
Custom feed path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,21 @@ The plugin will automatically use any of the following configuration variables, 
 * `name` - The title of the site, e.g., "My awesome site"
 * `description` - A longer description of what your site is about, e.g., "Where I blog about Jekyll and other awesome things"
 * `url` - The URL to your site, e.g., `http://example.com`. If none is provided, the plugin will try to use `site.github.url`.
-* `feed_path` - The path to the generated feed, e.g., `atom.xml`. If none is provided, the plugin will default to `feed.xml`.
 * `author` - Your name, e.g., "Dr. Jekyll." This can be a string (with the author's name), or an object with the following properties:
   - `name` - **Required** Display name of the author
   - `email` - Email address of the author
   - `uri` - Webpage where more information about the author can be found
 
+### Already have a feed path?
+
+Do you already have an existing feed someplace other than `/feed.xml`, but are on a host like GitHub Pages that doesn't support machine-friendly redirects? If you simply swap out `jekyll-feed` for your existing template, your existing subscribers won't continue to get updates. Instead, you can specify a non-default path via your site's config.
+
+```yml
+feed:
+  path: atom.xml
+```
+
+To note, you shouldn't have to do this unless you already have a feed you're using, and you can't or wish not to redirect existing subscribers.
 
 ### Optional front matter
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The plugin will automatically use any of the following configuration variables, 
 * `name` - The title of the site, e.g., "My awesome site"
 * `description` - A longer description of what your site is about, e.g., "Where I blog about Jekyll and other awesome things"
 * `url` - The URL to your site, e.g., `http://example.com`. If none is provided, the plugin will try to use `site.github.url`.
+* `feed_path` - The path to the generated feed, e.g., `atom.xml`. If none is provided, the plugin will default to `feed.xml`.
 * `author` - Your name, e.g., "Dr. Jekyll." This can be a string (with the author's name), or an object with the following properties:
   - `name` - **Required** Display name of the author
   - `email` - Email address of the author

--- a/lib/jekyll-feed.rb
+++ b/lib/jekyll-feed.rb
@@ -13,7 +13,11 @@ module Jekyll
     end
 
     def path
-      config["feed_path"] || "feed.xml"
+      if config["feed"] && config["feed"]["path"]
+        config["feed"]["path"]
+      else
+        "feed.xml"
+      end
     end
 
     def url
@@ -36,7 +40,11 @@ module Jekyll
 
     # Path to feed from config, or feed.xml for default
     def path
-      @site.config["feed_path"] || "feed.xml"
+      if @site.config["feed"] && @site.config["feed"]["path"]
+        @site.config["feed"]["path"]
+      else
+        "feed.xml"
+      end
     end
 
     # Main plugin action, called by Jekyll-core

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -150,7 +150,7 @@ describe(Jekyll::JekyllFeed) do
     let(:config) do
       Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"feed" => {"path" => "atom.xml"}}))
     end
-    let(:contents) { File.read(dest_dir("feed.xml")) }
+    let(:contents) { File.read(dest_dir("atom.xml")) }
 
     it "should write to atom.xml" do
       expect(File.exist?(dest_dir("atom.xml"))).to be_truthy

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -145,4 +145,21 @@ describe(Jekyll::JekyllFeed) do
       expect(index).to include(expected)
     end
   end
+
+  context "changing the feed path" do
+    let(:config) do
+      Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"feed_path" => "atom.xml"}))
+    end
+    let(:contents) { File.read(dest_dir("feed.xml")) }
+
+    it "should write to atom.xml" do
+      expect(File.exist?(dest_dir("atom.xml"))).to be_truthy
+    end
+
+    it "renders the feed meta with custom feed path" do
+      index = File.read(dest_dir("index.html"))
+      expected = '<link type="application/atom+xml" rel="alternate" href="http://example.org/atom.xml" title="My awesome site" />'
+      expect(index).to include(expected)
+    end
+  end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -148,7 +148,7 @@ describe(Jekyll::JekyllFeed) do
 
   context "changing the feed path" do
     let(:config) do
-      Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"feed_path" => "atom.xml"}))
+      Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"feed" => {"path" => "atom.xml"}}))
     end
     let(:contents) { File.read(dest_dir("feed.xml")) }
 

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -30,7 +30,7 @@ describe(Jekyll::JekyllFeed) do
   end
 
   it "creates a feed.xml file" do
-    expect(File.exist?(dest_dir("feed.xml"))).to be_truthy
+    expect(Pathname.new(dest_dir("feed.xml"))).to exist
   end
 
   it "doesn't have multiple new lines or trailing whitespace" do
@@ -153,7 +153,7 @@ describe(Jekyll::JekyllFeed) do
     let(:contents) { File.read(dest_dir("atom.xml")) }
 
     it "should write to atom.xml" do
-      expect(File.exist?(dest_dir("atom.xml"))).to be_truthy
+      expect(Pathname.new(dest_dir("atom.xml"))).to exist
     end
 
     it "renders the feed meta with custom feed path" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -150,8 +150,7 @@ describe(Jekyll::JekyllFeed) do
     let(:config) do
       Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"feed" => {"path" => "atom.xml"}}))
     end
-    let(:contents) { File.read(dest_dir("atom.xml")) }
-
+    
     it "should write to atom.xml" do
       expect(Pathname.new(dest_dir("atom.xml"))).to exist
     end


### PR DESCRIPTION
Many sites already have feeds setup at a path other than `feed.xml`. If their host e.g., GitHub pages, doesn’t allow for redirects, changing to a new feed path isn’t really an option.

This PR adds a `_config.yml` option of `feed_path`, which defaults to `feed.xml` but can be set to a custom path like `atom.xml`.