### PR TITLE
Properly render post content with Jekyll

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -49,7 +49,7 @@
       {% endif %}
 
       <id>{{ post.id | prepend: url_base | xml_escape }}</id>
-      <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">{{ post.content | markdownify | strip | xml_escape }}</content>
+      <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
 
       {% if post.author %}
         <author>
@@ -76,7 +76,7 @@
       {% endfor %}
 
       {% if post.excerpt and post.excerpt != empty %}
-        <summary>{{ post.excerpt | markdownify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
+        <summary>{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
       {% endif %}
     </entry>
   {% endfor %}

--- a/lib/jekyll-feed.rb
+++ b/lib/jekyll-feed.rb
@@ -58,9 +58,7 @@ module Jekyll
       @site = site
       @site.config["time"] = Time.new
       unless feed_exists?
-        write
-        @site.keep_files ||= []
-        @site.keep_files << path
+        @site.pages << feed_content
       end
     end
 
@@ -69,27 +67,13 @@ module Jekyll
       File.expand_path "feed.xml", File.dirname(__FILE__)
     end
 
-    # Destination for feed.xml file within the site source directory
-    def destination_path
-      if @site.respond_to?(:in_dest_dir)
-        @site.in_dest_dir(path)
-      else
-        Jekyll.sanitized_path(@site.dest, path)
-      end
-    end
-
-    # copy feed template from source to destination
-    def write
-      FileUtils.mkdir_p File.dirname(destination_path)
-      File.open(destination_path, 'w') { |f| f.write(feed_content) }
-    end
-
     def feed_content
-      site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", path)
-      site_map.content = File.read(source_path).gsub(/\s*\n\s*/, "\n").gsub(/\n{%/, "{%")
-      site_map.data["layout"] = nil
-      site_map.render(Hash.new, @site.site_payload)
-      site_map.output
+      feed = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", path)
+      feed.content = File.read(source_path).gsub(/\s*\n\s*/, "\n").gsub(/\s+{%/, "{%").gsub(/\s+</,"<")
+      feed.data["layout"] = nil
+      feed.data['sitemap'] = false
+      feed.output
+      feed
     end
 
     # Checks if a feed already exists in the site source

--- a/lib/jekyll-feed.rb
+++ b/lib/jekyll-feed.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+require "fileutils"
 
 module Jekyll
   class PageWithoutAFile < Page
@@ -71,7 +71,7 @@ module Jekyll
       feed = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", path)
       feed.content = File.read(source_path).gsub(/\s*\n\s*/, "\n").gsub(/\s+{%/, "{%").gsub(/\s+</,"<")
       feed.data["layout"] = nil
-      feed.data['sitemap'] = false
+      feed.data["sitemap"] = false
       feed.output
       feed
     end
@@ -91,4 +91,4 @@ unless defined? Liquid::StandardFilters.strip
     Liquid::Template.register_filter(Jekyll::StripWhitespace)
 end
 
-Liquid::Template.register_tag('feed_meta', Jekyll::FeedMetaTag)
+Liquid::Template.register_tag("feed_meta", Jekyll::FeedMetaTag)

--- a/spec/fixtures/_posts/2015-05-12-liquid.md
+++ b/spec/fixtures/_posts/2015-05-12-liquid.md
@@ -1,0 +1,7 @@
+---
+---
+
+{% capture liquidstring %}
+Liquid is not rendered.
+{% endcapture %}
+{{ liquidstring | replace:'not ','' }}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -76,6 +76,11 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).to match /<title>The plugin will properly strip newlines.<\/title>/
   end
 
+  it "renders Liquid inside posts" do
+    expect(contents).to match /Liquid is rendered\./
+    expect(contents).not_to match /Liquid is not rendered\./
+  end
+
   context "parsing" do
     let(:feed) { RSS::Parser.parse(contents) }
 
@@ -95,7 +100,7 @@ describe(Jekyll::JekyllFeed) do
     end
 
     it "includes the items" do
-      expect(feed.items.count).to eql(7)
+      expect(feed.items.count).to eql(8)
     end
 
     it "includes item contents" do


### PR DESCRIPTION
Taking a shot at rendering the sitemap with Jekyll instead of writing it ourself. This means that posts will be properly rendered, instead of having us render them with the Markdown filter and hoping for the best.

This _will_ conflict with #67 in two ways:

 * The number of posts in the test has changed
 * This uses the `strip` filter, which is unavailable in Jekyll 2, but is added in #67

My goal was just to make things work while changing as little as possible, so please let me know if you see anything goofy.