### PR TITLE
Add Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,29 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 1.9
+  Include:
+    - lib/*.rb
+
+  Exclude:
+    - .rubocop.yml
+    - .codeclimate.yml
+    - .travis.yml
+    - .gitignore
+    - .rspec
+
+    - Gemfile.lock
+    - CHANGELOG.md
+    - readme.md
+    - README.md
+    - Readme.md
+    - ReadMe.md
+    - COPYING
+    - LICENSE
+
+    - test/**/*
+    - vendor/**/*
+    - features/**/*
+    - script/**/*
+    - spec/**/*

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,10 +14,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 2.4.0", "< 3.1.0"
+  spec.add_development_dependency "jekyll", ">= 2.4.0", "< 3.2.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "typhoeus", "~> 0.7"
   spec.add_development_dependency "nokogiri", "~> 1.6"
+  spec.add_development_dependency "rubocop"
 end

--- a/lib/jekyll/feed_meta_tag.rb
+++ b/lib/jekyll/feed_meta_tag.rb
@@ -1,9 +1,8 @@
 module Jekyll
   class FeedMetaTag < Liquid::Tag
-
     def render(context)
       @context = context
-      "<link type=\"application/atom+xml\" rel=\"alternate\" href=\"#{url}/#{path}\" title=\"#{config["name"]}\" />"
+      %(<link type="application/atom+xml" rel="alternate" href="#{url}/#{path}" title="#{config["name"]}" />)
     end
 
     private

--- a/lib/jekyll/jekyll-feed.rb
+++ b/lib/jekyll/jekyll-feed.rb
@@ -42,9 +42,9 @@ module Jekyll
     # Checks if a feed already exists in the site source
     def feed_exists?
       if @site.respond_to?(:in_source_dir)
-        File.exists? @site.in_source_dir(path)
+        File.exist? @site.in_source_dir(path)
       else
-        File.exists? Jekyll.sanitized_path(@site.source, path)
+        File.exist? Jekyll.sanitized_path(@site.source, path)
       end
     end
   end

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,4 +3,7 @@
 set -e
 
 bundle exec rspec
+if [ "$JEKYLL_VERSION" == "3.0" ]; then
+  bundle exec rubocop -S -D
+fi
 bundle exec rake build


### PR DESCRIPTION
**Do not merge** until after Jekyll 3.1.0 is released, as this depends on Jekyll's `.rubocop.yml` which was not added until after 3.0.2.

This will allow us to easily make sure we are following the same coding conventions as Jekyll. I have also updated `lib/jekyll-feed.rb` to follow those same conventions.