### PR TITLE
Do not let jekyll-last-modified-at break tests

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "typhoeus", "~> 0.7"
   spec.add_development_dependency "nokogiri", "~> 1.6"
-  spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
 end

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,8 +1,5 @@
 timezone: UTC
 
-gems:
-  - jekyll-last-modified-at
-
 defaults:
   -
     scope:

--- a/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
+++ b/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
@@ -1,4 +1,5 @@
 ---
+last_modified_at: 2015-05-12T13:27:59+00:00
 ---
 
 Please don't modify this file. It's modified time is important.


### PR DESCRIPTION
I don't know why #86 is failing tests on Travis, but I cannot reproduce locally.

Frankly, I don't much care if **jekyll-last-modified-at** is coming up with the correct date or not, so long as we are using what is provided in the `last_modified_at` property.

This removes the dev dependency on **jekyll-last-modified-at** and, hopefully, will make the tests a little less rickety…?