### PR TITLE
Only test against Jekyll 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,9 @@
 language: ruby
 rvm:
   - 2.2
-  - 2.1
-  - 2.0
-matrix:
-  include:
-    - # Ruby 1.9
-      rvm: 1.9
-      env: JEKYLL_VERSION=2.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  matrix:
-    - JEKYLL_VERSION=3.0
-    - JEKYLL_VERSION=2.5
 cache: bundler
 sudo: false
 before_script: bundle update

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,7 +3,5 @@
 set -e
 
 bundle exec rspec
-if [ "$JEKYLL_VERSION" == "3.0" ]; then
-  bundle exec rubocop -S -D
-fi
+bundle exec rubocop -S -D
 bundle exec rake build


### PR DESCRIPTION
This reduces the number of CI test environments from 7 to 1.

Since most of the business of this plugin is implemented in Liquid, *hopefully* we're not doing anything that might break in one version of Ruby and not another.

**This also drops tests against Jekyll 2.x**

I have not removed Jekyll 2.x from the `.gemspec`, I have only removed the tests.