### PR TITLE
Use site.title for meta tag if available

### DIFF
--- a/lib/jekyll/feed_meta_tag.rb
+++ b/lib/jekyll/feed_meta_tag.rb
@@ -2,7 +2,7 @@ module Jekyll
   class FeedMetaTag < Liquid::Tag
     def render(context)
       @context = context
-      %(<link type="application/atom+xml" rel="alternate" href="#{url}/#{path}" title="#{config["name"]}" />)
+      %(<link type="application/atom+xml" rel="alternate" href="#{url}/#{path}" title="#{title}" />)
     end
 
     private
@@ -25,6 +25,10 @@ module Jekyll
       elsif config["github"] && config["github"]["url"]
         config["github"]["url"]
       end
+    end
+
+    def title
+      config["title"] || config["name"]
     end
   end
 end

--- a/lib/jekyll/feed_meta_tag.rb
+++ b/lib/jekyll/feed_meta_tag.rb
@@ -2,13 +2,23 @@ module Jekyll
   class FeedMetaTag < Liquid::Tag
     def render(context)
       @context = context
-      %(<link type="application/atom+xml" rel="alternate" href="#{url}/#{path}" title="#{title}" />)
+      attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(' ')
+      "<link #{attrs} />"
     end
 
     private
 
     def config
       @context.registers[:site].config
+    end
+
+    def attributes
+      {
+        :type => 'application/atom+xml',
+        :rel => 'alternate',
+        :href => "#{url}/#{path}",
+        :title => title
+      }.keep_if { |_, v| v }
     end
 
     def path

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -208,6 +208,20 @@ describe(Jekyll::JekyllFeed) do
       expected = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" title="My awesome site" />'
       expect(feed_meta).to eql(expected)
     end
+
+    context "with a blank site name" do
+      let(:config) do
+        Jekyll.configuration({
+          "source"      => source_dir,
+          "destination" => dest_dir,
+          "url"         => "http://example.org"
+        })
+      end
+
+      it "does not output blank title" do
+        expect(feed_meta).not_to include('title=')
+      end
+    end
   end
 
   context "changing the feed path" do


### PR DESCRIPTION
This will use `site.title` (if present) for the feed title when rendering the `<link>` tag. If `site.title` is undefined, it will fallback to `site.name`.

This mirrors the current behavior of the [feed itself](https://github.com/jekyll/jekyll-feed/blob/v0.4.0/lib/feed.xml#L14-L18):

```html
  {% if site.title %}
    <title>{{ site.title | xml_escape }}</title>
  {% elsif site.name %}
    <title>{{ site.name | xml_escape }}</title>
  {% endif %}
```