### PR TITLE
Quiet known warnings in tests

### DIFF
--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -165,6 +165,13 @@ describe(Jekyll::JekyllFeed) do
       result.css("warning").each do |warning|
         # Quiet a warning that results from us passing the feed as a string
         next if warning.css("text").text =~ /Self reference doesn't match document location/
+
+        # Quiet expected warning that results from blank summary test case
+        next if warning.css("text").text =~ /(content|summary) should not be blank/
+
+        # Quiet expected warning about multiple posts with same updated time
+        next if warning.css("text").text =~ /Two entries with the same value for atom:updated/
+
         warn "Validation warning: #{warning.css("text").text} on line #{warning.css("line").text} column #{warning.css("column").text}"
       end
 


### PR DESCRIPTION
Every time I test, I see

```text
Randomized with seed 16380
............................Validation warning: Two entries with the same value for atom:updated on line 5 column 239
Validation warning: content should not be blank on line 5 column 898
Validation warning: summary should not be blank on line 5 column 917
.

Finished in 3.26 seconds (files took 0.884 seconds to load)
29 examples, 0 failures
```

*These* warnings are just noise. The `content` and `summary` warnings come from a test case that checks for blank content. The warning about duplicate `atom:updated` values is just because several files were added to the git repo at once.

I want to make sure that nothing we change accidentally introduces new warnings.

These expected warnings are just ignored, and so should not even appear in the test output.