### PR TITLE
Add support for post image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ There are several ways to convey author-specific information. Author information
   ```
 
 * `image` - URL of an image that is representative of the post.  
-  **Note:** URL must be relative to the site root, eg: `/images/example.png`
 
 ### Meta tags
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ There are several ways to convey author-specific information. Author information
   author: benbalter
   ```
 
+* `image` - URL of an image that is representative of the post.  
+  **Note:** URL must be relative to the site root, eg: `/images/example.png`
+
 ### Meta tags
 
 The plugin exposes a helper tag to expose the appropriate meta tags to support automated discovery of your feed. Simply place `{% feed_meta %}` someplace in your template's `<head>` section, to output the necessary metadata.

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -95,6 +95,10 @@
       {% if post.excerpt and post.excerpt != empty %}
         <summary>{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
       {% endif %}
+
+      {% if post.image %}
+        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post.image | prepend: url_base | xml_escape }}" />
+      {% endif %}
     </entry>
   {% endunless %}
   {% endfor %}

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -96,8 +96,12 @@
         <summary>{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
       {% endif %}
 
-      {% if post.image %}
-        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post.image | prepend: url_base | xml_escape }}" />
+      {% assign post_image = post.image %}
+      {% if post_image %}
+        {% unless post_image contains "://" %}
+          {% assign post_image = post_image | prepend: url_base | xml_escape  %}
+        {% endunless %}
+        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image }}" />
       {% endif %}
     </entry>
   {% endunless %}

--- a/spec/fixtures/_posts/2013-12-12-dec-the-second.md
+++ b/spec/fixtures/_posts/2013-12-12-dec-the-second.md
@@ -1,5 +1,6 @@
 ---
 excerpt: "Foo"
+image: "/image.png"
 ---
 
 # December the twelfth, actually.

--- a/spec/fixtures/_posts/2014-03-02-march-the-second.md
+++ b/spec/fixtures/_posts/2014-03-02-march-the-second.md
@@ -1,4 +1,5 @@
 ---
+image: "https://cdn.example.org/absolute.png"
 ---
 
 March the second!

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -85,6 +85,10 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).not_to match /Liquid is not rendered\./
   end
 
+  it "includes the item image" do
+    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/image.png" />')
+  end
+
   context "parsing" do
     let(:feed) { RSS::Parser.parse(contents) }
 

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -87,6 +87,7 @@ describe(Jekyll::JekyllFeed) do
 
   it "includes the item image" do
     expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/image.png" />')
+    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="https://cdn.example.org/absolute.png" />')
   end
 
   context "parsing" do


### PR DESCRIPTION
Uses the same `post.image` as used by [**jekyll-seo-tag**](https://github.com/jekyll/jekyll-seo-tag/blob/v1.3.2/lib/template.html#L91-L93)

Fixes #14