### PR TITLE
Drop support for Jekyll 2

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 2.4.0", "< 3.2.0"
+  spec.add_development_dependency "jekyll", ">= 3.0.0", "< 3.2.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -44,9 +44,7 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).to match /http:\/\/example\.org\/2014\/03\/04\/march-the-fourth\.html/
     expect(contents).to match /http:\/\/example\.org\/2014\/03\/02\/march-the-second\.html/
     expect(contents).to match /http:\/\/example\.org\/2013\/12\/12\/dec-the-second\.html/
-    if Gem::Version.new(Jekyll::VERSION) > Gem::Version.new('3')
-      expect(contents).to_not match /http:\/\/example\.org\/2016\/02\/09\/a-draft\.html/
-    end
+    expect(contents).to_not match /http:\/\/example\.org\/2016\/02\/09\/a-draft\.html/
   end
 
   it "does not include assets or any static files that aren't .html" do
@@ -106,11 +104,7 @@ describe(Jekyll::JekyllFeed) do
     end
 
     it "includes the items" do
-      if Gem::Version.new(Jekyll::VERSION) > Gem::Version.new('3')
-        expect(feed.items.count).to eql(8)
-      else
-        expect(feed.items.count).to eql(9)
-      end
+      expect(feed.items.count).to eql(8)
     end
 
     it "includes item contents" do
@@ -126,11 +120,7 @@ describe(Jekyll::JekyllFeed) do
     end
 
     it "doesn't include the item's excerpt if blank" do
-      if Gem::Version.new(Jekyll::VERSION) > Gem::Version.new('3')
-        post = feed.items.first
-      else
-        post = feed.items.fetch(1)
-      end
+      post = feed.items.first
       expect(post.summary).to be_nil
     end
 


### PR DESCRIPTION
As an addendum to #99, this drops test support for Jekyll 2 and bumps the required version of Jekyll.