### PR TITLE
Fix mangling of whitespace when `site.lang` is set

### DIFF
--- a/lib/jekyll/jekyll-feed.rb
+++ b/lib/jekyll/jekyll-feed.rb
@@ -32,7 +32,8 @@ module Jekyll
 
     def feed_content
       feed = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", path)
-      feed.content = File.read(source_path).gsub(/\s+([{<])/, '\1')
+      content = File.read(source_path).gsub(/(?<!\")\s+([<{])/, '\1')
+      feed.content = content
       feed.data["layout"] = nil
       feed.data["sitemap"] = false
       feed.output

--- a/lib/jekyll/jekyll-feed.rb
+++ b/lib/jekyll/jekyll-feed.rb
@@ -32,8 +32,7 @@ module Jekyll
 
     def feed_content
       feed = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", path)
-      content = File.read(source_path).gsub(/(?<!\")\s+([<{])/, '\1')
-      feed.content = content
+      feed.content = File.read(source_path).gsub(/(?<!\")\s+([<{])/, '\1')
       feed.data["layout"] = nil
       feed.data["sitemap"] = false
       feed.output

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -244,4 +244,12 @@ describe(Jekyll::JekyllFeed) do
       expect(feed_meta).to include(expected)
     end
   end
+
+  context "with site.lang set" do
+    let(:overrides) { { "lang" => "en-US" } }
+
+    it "should set the language" do
+      expect(contents).to match %r{type="text/html" hreflang="en-US" />}
+    end
+  end
 end


### PR DESCRIPTION
Which slams `hreflang` into the preceding attribute, causing parse errors.

This just adds a quick negative look behind to change the whitespace stripping behavior.