### PR TITLE
Added test for _data/authors.yml data and corrected mistakes

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -67,11 +67,15 @@
           {% assign post_author_uri = post_author.uri %}
         {% else %}
           {% if site.data.authors and site.data.authors[post_author] %}
-            {% assign post_author_email = site.data.authors[post_author].uri %}
+            {% assign post_author_uri = site.data.authors[post_author].uri %}
           {% endif %}
         {% endif %}
         {% if post_author.name %}
           {% assign post_author = post_author.name %}
+        {% else %}
+          {% if site.data.authors and site.data.authors[post_author] %}
+            {% assign post_author = site.data.authors[post_author].name %}
+          {% endif %}
         {% endif %}
         <author>
             <name>{{ post_author | xml_escape }}</name>

--- a/spec/fixtures/_data/authors.yml
+++ b/spec/fixtures/_data/authors.yml
@@ -1,0 +1,5 @@
+garthdb:
+  name: Garth
+  twitter: garthdb
+  uri: "http://garthdb.com"
+  email: example@mail.com

--- a/spec/fixtures/_posts/2016-04-25-author-reference.md
+++ b/spec/fixtures/_posts/2016-04-25-author-reference.md
@@ -1,0 +1,6 @@
+---
+excerpt: ""
+author: garthdb
+---
+
+# April the twenty-fifth?

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -68,6 +68,10 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).not_to match /<author>\s*<name><\/name>\s*<\/author>/
   end
 
+  it "does use author reference with data from _data/authors.yml" do
+    expect(contents).to match /<author>\s*<name>Garth<\/name>\s*<email>example@mail.com<\/email>\s*<uri>http:\/\/garthdb.com<\/uri>\s*<\/author>/
+  end
+
   it "converts markdown posts to HTML" do
     expect(contents).to match /&lt;p&gt;March the second!&lt;\/p&gt;/
   end
@@ -109,7 +113,7 @@ describe(Jekyll::JekyllFeed) do
     end
 
     it "includes the items" do
-      expect(feed.items.count).to eql(8)
+      expect(feed.items.count).to eql(9)
     end
 
     it "includes item contents" do


### PR DESCRIPTION
While trying to use referenced author data in the `_data/authors.yml` file as outlined in the documentation I found a couple mistakes in the [`lib/feed.xml`](https://github.com/jekyll/jekyll-feed/blob/master/lib/feed.xml) file:

* The `site.data.authors[author].uri` is being output in `<email>` [#L70](https://github.com/jekyll/jekyll-feed/blob/master/lib/feed.xml#L70)
* The `site.data.authors[author].name` is not being set, so the reference itself is output in `<name>` [#L74](https://github.com/jekyll/jekyll-feed/blob/master/lib/feed.xml#L74)

I also added a corresponding test with a `_data/authors.yml` file and post, with an author reference, to the `spec/fixtures` directory.

