### PR TITLE
Cleanup `post_author` logic

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -67,11 +67,15 @@
           {% assign post_author_uri = post_author.uri %}
         {% else %}
           {% if site.data.authors and site.data.authors[post_author] %}
-            {% assign post_author_email = site.data.authors[post_author].uri %}
+            {% assign post_author_uri = site.data.authors[post_author].uri %}
           {% endif %}
         {% endif %}
         {% if post_author.name %}
           {% assign post_author = post_author.name %}
+        {% else %}
+          {% if site.data.authors and site.data.authors[post_author] %}
+            {% assign post_author = site.data.authors[post_author].name %}
+          {% endif %}
         {% endif %}
         <author>
             <name>{{ post_author | xml_escape }}</name>

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -53,30 +53,12 @@
       <content type="html" xml:base="{{ post.url | prepend: url_base | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
-      {% assign post_author_email = false %}
-      {% assign post_author_uri = false %}
+      {% assign post_author = site.data.authors[post_author] | default: post_author %}
+      {% assign post_author_email = post_author.email | default: nil %}
+      {% assign post_author_uri = post_author.uri | default: nil %}
+      {% assign post_author = post_author.name | default: post_author %}
+
       {% if post_author %}
-        {% if post_author.email %}
-          {% assign post_author_email = post_author.email %}
-        {% else %}
-          {% if site.data.authors and site.data.authors[post_author] %}
-            {% assign post_author_email = site.data.authors[post_author].email %}
-          {% endif %}
-        {% endif %}
-        {% if post_author.uri %}
-          {% assign post_author_uri = post_author.uri %}
-        {% else %}
-          {% if site.data.authors and site.data.authors[post_author] %}
-            {% assign post_author_uri = site.data.authors[post_author].uri %}
-          {% endif %}
-        {% endif %}
-        {% if post_author.name %}
-          {% assign post_author = post_author.name %}
-        {% else %}
-          {% if site.data.authors and site.data.authors[post_author] %}
-            {% assign post_author = site.data.authors[post_author].name %}
-          {% endif %}
-        {% endif %}
         <author>
             <name>{{ post_author | xml_escape }}</name>
           {% if post_author_email %}

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -56,11 +56,11 @@
       {% assign post_author = site.data.authors[post_author] | default: post_author %}
       {% assign post_author_email = post_author.email | default: nil %}
       {% assign post_author_uri = post_author.uri | default: nil %}
-      {% assign post_author = post_author.name | default: post_author %}
+      {% assign post_author_name = post_author.name | default: post_author %}
 
       {% if post_author %}
         <author>
-            <name>{{ post_author | xml_escape }}</name>
+            <name>{{ post_author_name | xml_escape }}</name>
           {% if post_author_email %}
             <email>{{ post_author_email | xml_escape }}</email>
           {% endif %}

--- a/spec/fixtures/_data/authors.yml
+++ b/spec/fixtures/_data/authors.yml
@@ -1,0 +1,5 @@
+garthdb:
+  name: Garth
+  twitter: garthdb
+  uri: "http://garthdb.com"
+  email: example@mail.com

--- a/spec/fixtures/_posts/2016-04-25-author-reference.md
+++ b/spec/fixtures/_posts/2016-04-25-author-reference.md
@@ -1,0 +1,6 @@
+---
+excerpt: ""
+author: garthdb
+---
+
+# April the twenty-fifth?

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -68,6 +68,10 @@ describe(Jekyll::JekyllFeed) do
     expect(contents).not_to match /<author>\s*<name><\/name>\s*<\/author>/
   end
 
+  it "does use author reference with data from _data/authors.yml" do
+    expect(contents).to match /<author>\s*<name>Garth<\/name>\s*<email>example@mail.com<\/email>\s*<uri>http:\/\/garthdb.com<\/uri>\s*<\/author>/
+  end
+
   it "converts markdown posts to HTML" do
     expect(contents).to match /&lt;p&gt;March the second!&lt;\/p&gt;/
   end
@@ -109,7 +113,7 @@ describe(Jekyll::JekyllFeed) do
     end
 
     it "includes the items" do
-      expect(feed.items.count).to eql(8)
+      expect(feed.items.count).to eql(9)
     end
 
     it "includes item contents" do


### PR DESCRIPTION
As pointed out by @GarthDB in #111, the way we were doing it previously was a mess that camouflaged bugs. This builds on PR, further simplifying things and hopefully giving bugs fewer places to hide.