### PR TITLE
Use smartify filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,15 @@ There are several ways to convey author-specific information. Author information
   author: benbalter
   ```
 
-* `image` - URL of an image that is representative of the post.  
+* `image` - URL of an image that is representative of the post.
 
 ### Meta tags
 
 The plugin exposes a helper tag to expose the appropriate meta tags to support automated discovery of your feed. Simply place `{% feed_meta %}` someplace in your template's `<head>` section, to output the necessary metadata.
+
+### SmartyPants
+
+The plugin uses [Jekyll's `smartify` filter](https://jekyllrb.com/docs/templates/) for processing the site title and post titles. This will translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a title.
 
 ## Why Atom, and not RSS?
 

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 3.0.0", "< 3.2.0"
+  spec.add_development_dependency "jekyll", ">= 3.1.0", "< 3.2.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -13,9 +13,9 @@
   <id>{{ url_base | xml_escape }}/</id>
 
   {% if site.title %}
-    <title>{{ site.title | xml_escape }}</title>
+    <title>{{ site.title | smartify | xml_escape }}</title>
   {% elsif site.name %}
-    <title>{{ site.name | xml_escape }}</title>
+    <title>{{ site.name | smartify | xml_escape }}</title>
   {% endif %}
 
   {% if site.description %}
@@ -41,7 +41,7 @@
   {% for post in site.posts limit: 10 %}
   {% unless post.draft %}
     <entry{% if post.lang %} xml:lang="{{ post.lang }}"{% endif %}>
-      <title>{{ post.title | markdownify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
+      <title>{{ post.title | smartify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
       <link href="{{ post.url | prepend: url_base }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
       {% if post.last_modified_at %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -166,6 +166,16 @@ describe(Jekyll::JekyllFeed) do
     end
   end
 
+  context "smartify" do
+    let(:site_title) { "Pat's Site" }
+    let(:overrides) { { "title" => site_title } }
+    let(:feed) { RSS::Parser.parse(contents) }
+
+    it "processes site title with SmartyPants" do
+      expect(feed.title.content).to eql("Pat’s Site")
+    end
+  end
+
   context "validation" do
     it "validates" do
       # See https://validator.w3.org/docs/api.html


### PR DESCRIPTION
Requires Jekyll 3.1

Processes most strings with SmartyPants to replace characters with their fancy typographic equivalent.