### PR TITLE
Use type="html" to skirt around double escaping problem

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -13,9 +13,9 @@
   <id>{{ url_base | xml_escape }}/</id>
 
   {% if site.title %}
-    <title>{{ site.title | smartify | xml_escape }}</title>
+    <title type="html">{{ site.title | smartify | xml_escape }}</title>
   {% elsif site.name %}
-    <title>{{ site.name | smartify | xml_escape }}</title>
+    <title type="html">{{ site.name | smartify | xml_escape }}</title>
   {% endif %}
 
   {% if site.description %}
@@ -41,7 +41,7 @@
   {% for post in site.posts limit: 10 %}
   {% unless post.draft %}
     <entry{% if post.lang %} xml:lang="{{ post.lang }}"{% endif %}>
-      <title>{{ post.title | smartify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
+      <title type="html">{{ post.title | smartify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
       <link href="{{ post.url | prepend: url_base }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
       {% if post.last_modified_at %}
@@ -80,7 +80,7 @@
       {% endfor %}
 
       {% if post.excerpt and post.excerpt != empty %}
-        <summary>{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
+        <summary type="html">{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
       {% endif %}
 
       {% assign post_image = post.image %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -85,7 +85,7 @@ describe(Jekyll::JekyllFeed) do
   end
 
   it "replaces newlines in posts to spaces" do
-    expect(contents).to match /<title>The plugin will properly strip newlines.<\/title>/
+    expect(contents).to match %r!<title type="html">The plugin will properly strip newlines.</title>!
   end
 
   it "renders Liquid inside posts" do


### PR DESCRIPTION
I really wanted to find a way to just avoid double-escaping the entities, but I have not. It seems this will work instead.

Fixes #98 