### PR TITLE
Assign `url_base` before first usage

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-stylesheet type="text/xml" href="{{ url_base }}/feed.xslt.xml"?>
 {% if site.url %}
   {% assign url_base = site.url | append: site.baseurl %}
 {% else %}
   {% assign url_base = site.github.url %}
 {% endif %}
+<?xml-stylesheet type="text/xml" href="{{ url_base }}/feed.xslt.xml"?>
 <feed xmlns="http://www.w3.org/2005/Atom"{% if site.lang %} xml:lang="{{ site.lang }}"{% endif %}>
   <generator uri="http://jekyllrb.com" version="{{ jekyll.version }}">Jekyll</generator>
   <link href="{{ page.url | prepend: url_base }}" rel="self" type="application/atom+xml" />

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -265,7 +265,7 @@ describe(Jekyll::JekyllFeed) do
 
   context "feed stylesheet" do
     it "includes a default stylesheet" do
-      expect(contents).to include('<?xml-stylesheet type="text/xml" href="/feed.xslt.xml"?>')
+      expect(contents).to include('<?xml-stylesheet type="text/xml" href="http://example.org/feed.xslt.xml"?>')
     end
   end
 


### PR DESCRIPTION
This builds on #132 by fixing the failing test that did not expect the stylesheet URL to have `url_base` prepended.

Thanks so much @digitalvapor for doing the leg work on this.

Fixes #131