### PR TITLE
Use new `normalize_whitespace` filter

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -32,7 +32,7 @@
   {% for post in site.posts limit: 10 %}
   {% unless post.draft %}
     <entry{% if post.lang %} xml:lang="{{ post.lang }}"{% endif %}>
-      <title type="html">{{ post.title | smartify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
+      <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
       <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
@@ -66,7 +66,7 @@
       {% endfor %}
 
       {% if post.excerpt and post.excerpt != empty %}
-        <summary type="html">{{ post.excerpt | strip_html | replace: '\n', ' ' | strip | xml_escape }}</summary>
+        <summary type="html">{{ post.excerpt | strip_html | normalize_whitespace | xml_escape }}</summary>
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}


### PR DESCRIPTION
[`normalize_whitespace`](https://github.com/jekyll/jekyll/blob/v3.2.0/lib/jekyll/filters.rb#L153-L160) will replace any run of whitespace (including newlines) with a single space, and strip all space from the beginning and end. :+1: