### PR TITLE
Use absolute_url to generate the feed_meta url

### DIFF
--- a/lib/jekyll/feed_meta_tag.rb
+++ b/lib/jekyll/feed_meta_tag.rb
@@ -1,5 +1,8 @@
 module Jekyll
   class FeedMetaTag < Liquid::Tag
+    # Use Jekyll's native relative_url filter
+    include Jekyll::Filters::URLFilters
+
     def render(context)
       @context = context
       attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(" ")
@@ -16,7 +19,7 @@ module Jekyll
       {
         :type  => "application/atom+xml",
         :rel   => "alternate",
-        :href  => "#{url}/#{path}",
+        :href  => absolute_url(path),
         :title => title
       }.keep_if { |_, v| v }
     end
@@ -26,14 +29,6 @@ module Jekyll
         config["feed"]["path"]
       else
         "feed.xml"
-      end
-    end
-
-    def url
-      if config["url"]
-        URI.join(config["url"], config["baseurl"])
-      elsif config["github"] && config["github"]["url"]
-        config["github"]["url"]
       end
     end
 


### PR DESCRIPTION
Rather than writing our own URL logic, lets just let Jekyll do the heavy lifting for us.

This should be a backwards compatible change.