### PR TITLE
Feed entries must contain <author>

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -47,17 +47,15 @@
       {% assign post_author_uri = post_author.uri | default: nil %}
       {% assign post_author_name = post_author.name | default: post_author %}
 
-      {% if post_author %}
-        <author>
-            <name>{{ post_author_name | xml_escape }}</name>
-          {% if post_author_email %}
-            <email>{{ post_author_email | xml_escape }}</email>
-          {% endif %}
-          {% if post_author_uri %}
-            <uri>{{ post_author_uri | xml_escape }}</uri>
-          {% endif %}
-        </author>
-      {% endif %}
+      <author>
+          <name>{{ post_author_name | xml_escape }}</name>
+        {% if post_author_email %}
+          <email>{{ post_author_email | xml_escape }}</email>
+        {% endif %}
+        {% if post_author_uri %}
+          <uri>{{ post_author_uri | xml_escape }}</uri>
+        {% endif %}
+      </author>
 
       {% if post.category %}
         <category term="{{ post.category | xml_escape }}" />

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -48,7 +48,7 @@
       {% assign post_author_name = post_author.name | default: post_author %}
 
       <author>
-          <name>{{ post_author_name | xml_escape }}</name>
+          <name>{{ post_author_name | default: "" | xml_escape }}</name>
         {% if post_author_email %}
           <email>{{ post_author_email | xml_escape }}</email>
         {% endif %}


### PR DESCRIPTION
If no author is set, this will output `<author><name></name></author>`.

Feed validator will _recommend_ not having a blank `name`, but this will validate where previously it would not, because `<author>` is a required child of `<entry>`

Fixes #146

/cc: @dret @zixia 