### PR TITLE
Test feeds that have a `site.lang`

### DIFF
--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -105,6 +105,7 @@ describe(JekyllFeed) do
       expect(feed.feed_version).to eql("1.0")
       expect(feed.encoding).to eql("UTF-8")
       expect(feed.lang).to be_nil
+      expect(feed.valid?).to eql(true)
     end
 
     it "outputs the link" do
@@ -144,6 +145,7 @@ describe(JekyllFeed) do
         expect(feed.feed_type).to eql("atom")
         expect(feed.feed_version).to eql("1.0")
         expect(feed.encoding).to eql("UTF-8")
+        expect(feed.valid?).to eql(true)
       end
 
       it "outputs the correct language" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -156,6 +156,11 @@ describe(JekyllFeed) do
         post = feed.items.first
         expect(post.lang).to eql(lang)
       end
+
+      it "renders the feed meta" do
+        expected = %r!<link href="http://example.org/" rel="alternate" type="text/html" hreflang="#{lang}" />!
+        expect(contents).to match(expected)
+      end
     end
 
     context "with site.title set" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -104,6 +104,7 @@ describe(JekyllFeed) do
       expect(feed.feed_type).to eql("atom")
       expect(feed.feed_version).to eql("1.0")
       expect(feed.encoding).to eql("UTF-8")
+      expect(feed.lang).to be_nil
     end
 
     it "outputs the link" do
@@ -134,6 +135,20 @@ describe(JekyllFeed) do
     it "doesn't include the item's excerpt if blank" do
       post = feed.items.first
       expect(post.summary).to be_nil
+    end
+
+    context "with site.lang set" do
+      lang = "en_US"
+      let(:overrides) { {"lang" => lang} }
+      it "outputs a valid feed" do
+        expect(feed.feed_type).to eql("atom")
+        expect(feed.feed_version).to eql("1.0")
+        expect(feed.encoding).to eql("UTF-8")
+      end
+
+      it "outputs the correct language" do
+        expect(feed.lang).to match(lang)
+      end
     end
 
     context "with site.title set" do
@@ -265,14 +280,6 @@ describe(JekyllFeed) do
   context "feed stylesheet" do
     it "includes the stylesheet" do
       expect(contents).to include('<?xml-stylesheet type="text/xml" href="http://example.org/feed.xslt.xml"?>')
-    end
-  end
-
-  context "with site.lang set" do
-    let(:overrides) { { "lang" => "en-US" } }
-
-    it "should set the language" do
-      expect(contents).to match %r{type="text/html" hreflang="en-US" />}
     end
   end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -149,7 +149,12 @@ describe(JekyllFeed) do
       end
 
       it "outputs the correct language" do
-        expect(feed.lang).to match(lang)
+        expect(feed.lang).to eql(lang)
+      end
+
+      it "sets the language of entries" do
+        post = feed.items.first
+        expect(post.lang).to eql(lang)
       end
     end
 


### PR DESCRIPTION
See #162 #163