### PR TITLE
fix <entry> template for posts with post.lang defined

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -33,7 +33,7 @@
 
   {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
   {% for post in posts limit: 10 %}
-    <entry{% if post.lang %} xml:lang="{{ post.lang }}"{% endif %}>
+    <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
       <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>

--- a/spec/fixtures/_posts/2015-05-12-pre.html
+++ b/spec/fixtures/_posts/2015-05-12-pre.html
@@ -1,5 +1,6 @@
 ---
 author: Pat
+lang: en
 ---
 
 <pre>Line 1

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -275,4 +275,11 @@ describe(JekyllFeed) do
       expect(contents).to match %r{type="text/html" hreflang="en-US" />}
     end
   end
+
+  context "with post.lang set"do
+    it "should set the language for that entry" do
+      expect(contents).to match %r{<entry xml:lang="en">}
+      expect(contents).to match %r{<entry>}
+    end
+  end
 end


### PR DESCRIPTION
It has been outputting invalid XML like `<entryxml:lang="en">`.

I am not familiar with this template syntax. Please let me know if the fix can be prettier.

-------

This should solve #167 . My bad, should had a look at existing issues first.