### PR TITLE
Create JSON feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jekyll Feed plugin
 
-A Jekyll plugin to generate an Atom (RSS-like) feed of your Jekyll posts
+A Jekyll plugin to generate an Atom (RSS-like) feed and a [JSON feed](https://jsonfeed.org/version/1) of your Jekyll posts
 
 [![Build Status](https://travis-ci.org/jekyll/jekyll-feed.svg)](https://travis-ci.org/jekyll/jekyll-feed) [![Gem Version](https://badge.fury.io/rb/jekyll-feed.svg)](https://badge.fury.io/rb/jekyll-feed)
 
@@ -39,6 +39,7 @@ Do you already have an existing feed someplace other than `/feed.xml`, but are o
 ```yml
 feed:
   path: atom.xml
+  json_path: json_feed.json
 ```
 
 To note, you shouldn't have to do this unless you already have a feed you're using, and you can't or wish not to redirect existing subscribers.

--- a/lib/jekyll-feed/feed.json
+++ b/lib/jekyll-feed/feed.json
@@ -1,0 +1,63 @@
+{
+  "version": "https://jsonfeed.org/version/1",
+  {% assign site_title = site.title | site.name }
+  {% if site_title %}
+    "title": {{ site_title | smartify | json }},
+  {% endif %}
+  "home_page_url": "{{ '/' | absolute_url }}",
+  "feed_url": "{{ page.url | absolute_url }}",
+  {% if site.description }
+    "description": {{ site.description | json }},
+  {% endif %}
+  {% if site.author %}
+    "author": {
+      "name": {{ site.author.name | default: site.author | json }},
+      {% if site.author.uri %}
+        "url": {{ site.author.uri | json }},
+      {% endif %}
+    }
+  {% endif %}
+  "items": [
+    {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
+    {% for post in posts limmit: 10 %}
+      {
+        "id": {{ post.id | absolute_url | json }},
+        "url": "{{ post.url | absolute_url }}",
+        "title": {{ post.title | smartify | strip_html | normalize_whitespace | json }},
+        {% if post.excerpt and post.excerpt != empty %}
+          {% assign summary = post.excerpt | strip_html | normalize_whitespace | json %}
+          "content_html": {{ summary }},
+          "summary": {{ summary }},
+        {% endif %}
+        {% assign post_image = post.image.path | default: post.image %}
+        {% if post_image %}
+          {% unless post_image contains "://" %}
+            {% assign post_image = post_image | absolute_url | xml_escape  %}
+          {% endunless %}
+          "image": "{{ post_image }}",
+        {% endif %}
+        "date_published": "{{ post.date | date_to_xmlschema }}",
+        "date_modified": "{{ post.last_modified_at | default: post.date | date_to_xmlschema }}",
+        {% assign post_author = post.author | default: post.authors[0] %}
+        {% if post_author %}
+          {% assign post_author = site.data.authors[post_author] | default: post_author %}
+          {% assign post_author_uri = post_author.uri | default: nil %}
+          {% assign post_author_name = post_author.name | default: post_author %}
+          "author": {
+            {% if post_author_name %}
+              "name": {{ post_author_name | json }},
+            {% endif %}
+            {% if post_author_uri %}
+              "url": {{ post_author_uri | json }}
+            {% endif %}
+          }
+        {% endif %}
+        "tags": [
+          {% for tag in post.tags %}
+            {{ tag | json }}
+          {% endfor %}
+        ]
+      }
+    {% endfor %}
+  ]
+}

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -6,8 +6,10 @@ module JekyllFeed
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      return if file_exists?(feed_path)
+      
+      return if file_exists?(feed_path) and file_exists?(json_feed_path)
       @site.pages << xml_content_for_file(feed_path, feed_source_path)
+      @site.pages << json_content_for_file(json_feed_path, feed_json_source_path)
     end
 
     private

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -6,7 +6,7 @@ module JekyllFeed
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      
+
       return if file_exists?(feed_path) and file_exists?(json_feed_path)
       @site.pages << xml_content_for_file(feed_path, feed_source_path)
       @site.pages << json_content_for_file(json_feed_path, feed_json_source_path)
@@ -31,8 +31,8 @@ module JekyllFeed
 
     # Path to JSON feed from config, or feed.json for default
     def json_feed_path
-      if @site.config["feed"] && @site.config["feed"]["path"]
-        @site.config["feed"]["path"]
+      if @site.config["feed"] && @site.config["feed"]["json_path"]
+        @site.config["feed"]["json_path"]
       else
         "feed.json"
       end


### PR DESCRIPTION
The original spec for JSON Feeds has been published this morning ([Spec](https://jsonfeed.org/version/1)), and as my first Ruby exercise, I tried to create JSON feeds for Jekyll.

By default, the JSON feed will be written to feed.json, but a config option is also available. The JSON code should be valid, and I perform sanitization of strings by using the `json` Liquid operator.

Please note that this is the first time I've modified some Ruby code, and some things could be totally wrong (I'm not too sure about this [return](https://github.com/hugmanrique/jekyll-feed/blob/master/lib/jekyll-feed/generator.rb#L10))