### PR TITLE
Generate a feed for each category.

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -33,6 +33,11 @@
 
   {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
   {% for post in posts limit: 10 %}
+    {% if page.category %}
+      {% unless post.categories contains page.category %}
+        {% continue %}
+      {% endunless %}
+    {% endif %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
       <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -6,8 +6,15 @@ module JekyllFeed
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      return if file_exists?(feed_path)
-      @site.pages << content_for_file(feed_path, feed_source_path)
+      unless file_exists?(feed_path)
+        @site.pages << content_for_file(feed_path, feed_source_path)
+      end
+      @site.categories.each do |category|
+        path = "/feed/" + category.first + ".xml"
+        unless file_exists?(path)
+          @site.pages << content_for_file(path, feed_source_path, category.first)
+        end
+      end
     end
 
     private
@@ -42,12 +49,13 @@ module JekyllFeed
     end
 
     # Generates contents for a file
-    def content_for_file(file_path, file_source_path)
+    def content_for_file(file_path, file_source_path, category = false)
       file = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", file_path)
       file.content = File.read(file_source_path).gsub(MINIFY_REGEX, "")
       file.data["layout"] = nil
       file.data["sitemap"] = false
       file.data["xsl"] = file_exists?("feed.xslt.xml")
+      file.data["category"] = category
       file.output
       file
     end


### PR DESCRIPTION
Like others in #70, I want to have a feed per-category so that readers can subscribe only to topics that interest them. When testing this PR, you should be able to visit `/feed/category.xml`, where "category" is your category name.

I've only implemented categories here, as it seems like there would be loads of tags and users may expect complicated syntax like: `/feed/tag1/tag2/combined.xml`. Categories are how you categorize your content, so it makes sense that they would represent individual feeds.

I just started using Jekyll, and have never written Ruby/Liquid before, so forgive me if anything is amiss here.