### PR TITLE
Fix: Add note about using plugins instead of gems key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ gems:
   - jekyll-feed
 ```
 
+:bulb: If you are using Jekyll 3.5.0 or greater, you probably want to use the `plugins` key instead of `gems`.
+
 ## Usage
 
 The plugin will automatically generate an Atom feed at `/feed.xml`.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ gem 'jekyll-feed'
 And then add this line to your site's `_config.yml`:
 
 ```yml
-gems:
+plugins:
   - jekyll-feed
 ```
 
-:bulb: If you are using Jekyll 3.5.0 or greater, you probably want to use the `plugins` key instead of `gems`.
+:warning: If you are using Jekyll < 3.5.0 use the `gems` key instead of `plugins`.
 
 ## Usage
 


### PR DESCRIPTION
This PR

* [x] updates `README.md` with a note about using the `plugins` instead of the `gems` key for enabling the plugin

💁‍♂️ For reference, see https://github.com/jekyll/jekyll/pull/5130.