### PR TITLE
Dont forget about categories

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -59,6 +59,10 @@
 
       {% if post.category %}
         <category term="{{ post.category | xml_escape }}" />
+      {% elsif post.categories %}
+        {% for category in post.categories %}
+          <category term="{{ category | xml_escape }}" />
+        {% endfor %}
       {% endif %}
 
       {% for tag in post.tags %}


### PR DESCRIPTION
Since the frontmatter for posts can use `category` OR `categories` as per [documentation from jekyllrb.com](https://jekyllrb.com/docs/frontmatter/#predefined-variables-for-posts), it would make sense to also allow for categories to populate the XML data.

This change does not appear to be of a breaking type, as we already had the potential of multiple category tags from the combined use of `category` and `tags`. This just opens up the potential for even more `category` tags to be in the feed.xml thats output