### PR TITLE
Remove check for older version of Jekyll

### DIFF
--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -36,11 +36,7 @@ module JekyllFeed
 
     # Checks if a file already exists in the site source
     def file_exists?(file_path)
-      if @site.respond_to?(:in_source_dir)
-        File.exist? @site.in_source_dir(file_path)
-      else
-        File.exist? Jekyll.sanitized_path(@site.source, file_path)
-      end
+      File.exist? @site.in_source_dir(file_path)
     end
 
     # Generates contents for a file


### PR DESCRIPTION
Since the plugin requires `~> Jekyll 3.3`, the check for whether `site` responds to `in_source_dir` (available since Jekyll-3.0) is unnecessary.