### PR TITLE
Refactor to remove redundant calls and variables

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-	spec.add_development_dependency "rubocop", "~> 0.57.2"
+  spec.add_development_dependency "rubocop", "~> 0.57.2"
   spec.add_development_dependency "typhoeus", ">= 0.7", "< 2.0"
 end

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -14,7 +14,7 @@ module JekyllFeed
     private
 
     def config
-      @context.registers[:site].config
+      @config ||= @context.registers[:site].config
     end
 
     def attributes
@@ -27,11 +27,7 @@ module JekyllFeed
     end
 
     def path
-      if config["feed"] && config["feed"]["path"]
-        config["feed"]["path"]
-      else
-        "feed.xml"
-      end
+      config.dig("feed", "path") || "feed.xml"
     end
 
     def title


### PR DESCRIPTION
- replace `hash[key] && hash[key][subkey]` with simpler Ruby 2.3's `hash.dig(key, subkey)`
- memoize `config` stashes
- prefer `hash.each_value` to avoid unnecessary allotment for unused block parameter
- prefer `Object#tap` over explicit local variable assignment (*cosmetic change*)