### PR TITLE
Allow customising collection feed titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ feed:
       path: "/changes.xml"
 ```
 
+Collection feed titles will include the capitalized collection name. If you'd like to customize the feed title, specify a collection's custom title as follows:
+
+```yml
+feed:
+  collections:
+    changes:
+      title: "My collection title"
+```
+
 Finally, collections can also have category feeds which are outputted as `/feed/<COLLECTION>/<CATEGORY>.xml`. Specify categories like so:
 
 ```yml

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -9,19 +9,7 @@
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ page.url | absolute_url | xml_escape }}</id>
 
-  {% assign title = site.title | default: site.name %}
-  {% if page.collection != "posts" %}
-    {% assign collection = page.collection | capitalize %}
-    {% assign title = title | append: " | " | append: collection %}
-  {% endif %}
-  {% if page.category %}
-    {% assign category = page.category | capitalize %}
-    {% assign title = title | append: " | " | append: category %}
-  {% endif %}
-
-  {% if title %}
-    <title type="html">{{ title | smartify | xml_escape }}</title>
-  {% endif %}
+  <title type="html">{{ page.feed_title | smartify | xml_escape }}</title>
 
   {% if site.description %}
     <subtitle>{{ site.description | xml_escape }}</subtitle>

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -12,9 +12,10 @@ module JekyllFeed
         Jekyll.logger.info "Jekyll Feed:", "Generating feed for #{name}"
         (meta["categories"] + [nil]).each do |category|
           path = feed_path(:collection => name, :category => category)
+          feed_title = feed_title(:collection => name, :category => category)
           next if file_exists?(path)
 
-          @site.pages << make_page(path, :collection => name, :category => category)
+          @site.pages << make_page(path, feed_title, :collection => name, :category => category)
         end
       end
     end
@@ -46,6 +47,22 @@ module JekyllFeed
       return "#{prefix}/#{category}.xml" if category
 
       collections.dig(collection, "path") || "#{prefix}.xml"
+    end
+
+    # Determines the title of a given feed
+    #
+    # collection - the name of a collection, e.g., "posts"
+    # category - a category within that collection, e.g., "news"
+    #
+    # Will return the site title or name
+    # ...followed by collection title or capitalized name
+    # ...followed by capitalized category name
+    def feed_title(collection: "posts", category: nil)
+      words = []
+      words << (@site.config["title"] || @site.config["name"])
+      words << collections.dig(collection, "title") || collection.capitalize unless collection == "posts" # rubocop:disable Metrics/LineLength
+      words << category.capitalize if category
+      words.uniq.join " | "
     end
 
     # Returns a hash representing all collections to be processed and their metadata
@@ -85,7 +102,7 @@ module JekyllFeed
 
     # Generates contents for a file
 
-    def make_page(file_path, collection: "posts", category: nil)
+    def make_page(file_path, title, collection: "posts", category: nil)
       PageWithoutAFile.new(@site, __dir__, "", file_path).tap do |file|
         file.content = feed_template
         file.data.merge!(
@@ -93,7 +110,8 @@ module JekyllFeed
           "sitemap"    => false,
           "xsl"        => file_exists?("feed.xslt.xml"),
           "collection" => collection,
-          "category"   => category
+          "category"   => category,
+          "feed_title" => title
         )
         file.output
       end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -416,6 +416,31 @@ describe(JekyllFeed) do
       end
     end
 
+    context "with collection title" do
+      let(:collection_with_title_feed) { File.read(dest_dir("feed/collection_with_title.xml")) }
+      let(:overrides) do
+        {
+          "collections" => {
+            "collection_with_title" => {
+              "output" => true,
+              "path"   => 'collection_with_title'
+            },
+          },
+          "feed"        => {
+            "collections" => {
+              "collection_with_title" => {
+                "title" => "My collection title",
+              },
+            },
+          },
+        }
+      end
+
+      it "outputs the collection feed with custom title" do
+        expect(collection_with_title_feed).to match '<title type="html">My Awesome Site | My collection title</title>'
+      end
+    end
+
     context "with categories" do
       let(:overrides) do
         {


### PR DESCRIPTION
Allows customizing the feed title for a collection, in case you don't want to use the capitalized collection name. 