### PR TITLE
Improve collection and category management

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ There are several ways to convey author-specific information. Author information
 
 The plugin exposes a helper tag to expose the appropriate meta tags to support automated discovery of your feed. Simply place `{% feed_meta %}` someplace in your template's `<head>` section, to output the necessary metadata.
 
+The helper can also generate the link for a given collection: `{% feed_meta my_collection %}` or a given category: `{% feed_meta my_collection my_category %}`.
+
+To generate links for every collections and categories, call the helper using this syntax: `{% feed_meta include: all %}`.
+
 ### SmartyPants
 
 The plugin uses [Jekyll's `smartify` filter](https://jekyllrb.com/docs/templates/) for processing the site title and post titles. This will translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a title.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ feed:
       path: "/changes.xml"
 ```
 
+Collection feed titles will include the capitalized collection name. If you'd like to customize the feed title, specify a collection's custom title as follows:
+
+```yml
+feed:
+  collections:
+    changes:
+      title: "My collection title"
+```
+
 Finally, collections can also have category feeds which are outputted as `/feed/<COLLECTION>/<CATEGORY>.xml`. Specify categories like so:
 
 ```yml

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -9,19 +9,7 @@
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ page.url | absolute_url | xml_escape }}</id>
 
-  {% assign title = site.title | default: site.name %}
-  {% if page.collection != "posts" %}
-    {% assign collection = page.collection | capitalize %}
-    {% assign title = title | append: " | " | append: collection %}
-  {% endif %}
-  {% if page.category %}
-    {% assign category = page.category | capitalize %}
-    {% assign title = title | append: " | " | append: category %}
-  {% endif %}
-
-  {% if title %}
-    <title type="html">{{ title | smartify | xml_escape }}</title>
-  {% endif %}
+  <title type="html">{{ page.feed_title | smartify | xml_escape }}</title>
 
   {% if site.description %}
     <subtitle>{{ site.description | xml_escape }}</subtitle>

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -20,19 +20,6 @@ module JekyllFeed
       end
     end
 
-    private
-
-    # Matches all whitespace that follows
-    #   1. A '>', which closes an XML tag or
-    #   2. A '}', which closes a Liquid tag
-    # We will strip all of this whitespace to minify the template
-    MINIFY_REGEX = %r!(?<=>|})\s+!.freeze
-
-    # Returns the plugin's config or an empty hash if not set
-    def config
-      @config ||= @site.config["feed"] || {}
-    end
-
     # Determines the destination path of a given feed
     #
     # collection - the name of a collection, e.g., "posts"
@@ -46,7 +33,7 @@ module JekyllFeed
       prefix = collection == "posts" ? "/feed" : "/feed/#{collection}"
       return "#{prefix}/#{category}.xml" if category
 
-      collections.dig(collection, "path") || "#{prefix}.xml"
+      @collections.dig(collection, "path") || "#{prefix}.xml"
     end
 
     # Determines the title of a given feed
@@ -86,6 +73,19 @@ module JekyllFeed
       end
 
       @collections
+    end
+
+    private
+
+    # Matches all whitespace that follows
+    #   1. A '>', which closes an XML tag or
+    #   2. A '}', which closes a Liquid tag
+    # We will strip all of this whitespace to minify the template
+    MINIFY_REGEX = %r!(?<=>|})\s+!.freeze
+
+    # Returns the plugin's config or an empty hash if not set
+    def config
+      @config ||= @site.config["feed"] || {}
     end
 
     # Path to feed.xml template file

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -44,16 +44,13 @@ module JekyllFeed
 
     def attributes(collection, category)
       href = absolute_url(generator.feed_path(:collection => collection, :category => category))
+      title = generator.feed_title(:collection => collection, :category => category)
       {
         :type  => "application/atom+xml",
         :rel   => "alternate",
         :href  => href,
         :title => title,
-      }.keep_if { |_, v| v }
-    end
-
-    def title
-      config["title"] || config["name"]
+      }.delete_if { |_, v| v.strip.empty? }
     end
 
     def valid_collection

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -5,10 +5,26 @@ module JekyllFeed
     # Use Jekyll's native relative_url filter
     include Jekyll::Filters::URLFilters
 
+    def initialize(tag_name, args, tokens)
+      super
+      @args = args
+    end
+
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(" ")
-      "<link #{attrs} />"
+      if @args.strip == "include: all"
+        links = []
+        generator.collections.each do |collection, meta|
+          (meta["categories"] + [nil]).each do |category|
+            links << link(collection, category)
+          end
+        end
+        links.reverse.join "\n"
+      else
+        @collection, @category = @args.split(" ")
+        @collection ||= "posts"
+        link(@collection, @category) if valid_collection && valid_category
+      end
     end
 
     private
@@ -17,21 +33,50 @@ module JekyllFeed
       @config ||= @context.registers[:site].config
     end
 
-    def attributes
+    def generator
+      @generator ||= @context.registers[:site].generators.select { |it| it.is_a? JekyllFeed::Generator }.first # rubocop:disable Metrics/LineLength
+    end
+
+    def link(collection, category)
+      attrs = attributes(collection, category).map { |k, v| %(#{k}="#{v}") }.join(" ")
+      "<link #{attrs} />"
+    end
+
+    def attributes(collection, category)
+      href = absolute_url(generator.feed_path(:collection => collection, :category => category))
       {
         :type  => "application/atom+xml",
         :rel   => "alternate",
-        :href  => absolute_url(path),
+        :href  => href,
         :title => title,
       }.keep_if { |_, v| v }
     end
 
-    def path
-      config.dig("feed", "path") || "feed.xml"
-    end
-
     def title
       config["title"] || config["name"]
+    end
+
+    def valid_collection
+      return true if generator.collections.key? @collection
+
+      Jekyll.logger.warn(
+        "Jekyll Feed:",
+        "Invalid collection name. Please review `{% feed_meta #{@args} %}`"
+      )
+      false
+    end
+
+    def valid_category
+      return true if @collection == "posts" || @category.nil?
+
+      collection = generator.collections[@collection]
+      return true if collection.key?("categories") && collection["categories"].include?(@category)
+
+      Jekyll.logger.warn(
+        "Jekyll Feed:",
+        "Invalid category name. Please review `{% feed_meta #{@args} %}`"
+      )
+      false
     end
   end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -416,6 +416,31 @@ describe(JekyllFeed) do
       end
     end
 
+    context "with collection title" do
+      let(:collection_with_title_feed) { File.read(dest_dir("feed/collection_with_title.xml")) }
+      let(:overrides) do
+        {
+          "collections" => {
+            "collection_with_title" => {
+              "output" => true,
+              "path"   => 'collection_with_title'
+            },
+          },
+          "feed"        => {
+            "collections" => {
+              "collection_with_title" => {
+                "title" => "My collection title",
+              },
+            },
+          },
+        }
+      end
+
+      it "outputs the collection feed with custom title" do
+        expect(collection_with_title_feed).to match '<title type="html">My Awesome Site | My collection title</title>'
+      end
+    end
+
     context "with categories" do
       let(:overrides) do
         {

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -313,6 +313,66 @@ describe(JekyllFeed) do
     end
   end
 
+  context "selecting a particular collection" do
+    let(:overrides) do
+      {
+        "collections" => {
+          "collection" => {
+            "output" => true,
+          },
+        },
+        "feed"        => {
+          "collections" => {
+            "collection" => {
+              "categories" => ["news"],
+            },
+          },
+        },
+      }
+    end
+    let(:default_feed) { Liquid::Template.parse("{% feed_meta posts %}").render!(context, {}) }
+    let(:collection_feed) { Liquid::Template.parse("{% feed_meta collection %}").render!(context, {}) }
+    let(:category_feed) { Liquid::Template.parse("{% feed_meta collection news %}").render!(context, {}) }
+
+    it "renders the feed meta for the selected collection" do
+      default_feed_link    = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" title="My awesome site" />'
+      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site" />'
+      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site" />'
+      expect(default_feed).to eql(default_feed_link)
+      expect(collection_feed).to eql(collection_feed_link)
+      expect(category_feed).to eql(category_feed_link)
+    end
+  end
+
+  context "requesting all feed links" do
+    let(:overrides) do
+      {
+        "collections" => {
+          "collection" => {
+            "output" => true,
+          },
+        },
+        "feed"        => {
+          "collections" => {
+            "collection" => {
+              "categories" => ["news"],
+            },
+          },
+        },
+      }
+    end
+    let(:full_feed_meta) { Liquid::Template.parse("{% feed_meta include: all %}").render!(context, {}) }
+
+    it "renders the feed meta for all collections and categories" do
+      default_feed_link    = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" title="My awesome site" />'
+      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site" />'
+      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site" />'
+      expect(full_feed_meta).to include(default_feed_link)
+      expect(full_feed_meta).to include(collection_feed_link)
+      expect(full_feed_meta).to include(category_feed_link)
+    end
+  end
+
   context "feed stylesheet" do
     it "includes the stylesheet" do
       expect(contents).to include('<?xml-stylesheet type="text/xml" href="http://example.org/feed.xslt.xml"?>')

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -336,8 +336,8 @@ describe(JekyllFeed) do
 
     it "renders the feed meta for the selected collection" do
       default_feed_link    = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" title="My awesome site" />'
-      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site" />'
-      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site" />'
+      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site | Collection" />'
+      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site | Collection | News" />'
       expect(default_feed).to eql(default_feed_link)
       expect(collection_feed).to eql(collection_feed_link)
       expect(category_feed).to eql(category_feed_link)
@@ -365,8 +365,8 @@ describe(JekyllFeed) do
 
     it "renders the feed meta for all collections and categories" do
       default_feed_link    = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" title="My awesome site" />'
-      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site" />'
-      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site" />'
+      collection_feed_link = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection.xml" title="My awesome site | Collection" />'
+      category_feed_link   = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed/collection/news.xml" title="My awesome site | Collection | News" />'
       expect(full_feed_meta).to include(default_feed_link)
       expect(full_feed_meta).to include(collection_feed_link)
       expect(full_feed_meta).to include(category_feed_link)


### PR DESCRIPTION
This PR combines #253 and #254. The new behaviour is explained in the updated `README.md`.

TL;DR: if you're using collections and/or categories, replace `{% feed_meta %}` with `{% feed_meta include: all %}` to link to all available feeds, and eventually customise your collection feed titles.