### PR TITLE
Define `[nil]` as a constant under JekyllFeed

### DIFF
--- a/lib/jekyll-feed.rb
+++ b/lib/jekyll-feed.rb
@@ -5,6 +5,8 @@ require "fileutils"
 require "jekyll-feed/generator"
 
 module JekyllFeed
+  NIL_ARRAY = [nil].freeze
+
   autoload :MetaTag,          "jekyll-feed/meta-tag"
   autoload :PageWithoutAFile, "jekyll-feed/page-without-a-file.rb"
 end

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -10,7 +10,7 @@ module JekyllFeed
       @site = site
       collections.each do |name, meta|
         Jekyll.logger.info "Jekyll Feed:", "Generating feed for #{name}"
-        (meta["categories"] + [nil]).each do |category|
+        (meta["categories"] + JekyllFeed::NIL_ARRAY).each do |category|
           path = feed_path(:collection => name, :category => category)
           next if file_exists?(path)
 


### PR DESCRIPTION
To avoid unnecessary array allocations due to iterating through `collections`