### PR TITLE
Simplify interpolation by inspecting strings

### DIFF
--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -7,7 +7,7 @@ module JekyllFeed
 
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(" ")
+      attrs    = attributes.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")
       "<link #{attrs} />"
     end
 


### PR DESCRIPTION
- Since `%(#{k}="#{v}")` is a bit confusing to parse for a human..
- The other alternative is to escape double-quotes `"#{k}=\"#{v}\""` which I feel is uglier.
- `String#inspect` returns itself quoted and with any special characters escaped.