### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   Include:
     - lib/**/*.rb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: ruby
 cache: bundler
-sudo: false
 rvm:
-- 2.6
-- 2.4
+  - &latest_ruby 2.6
+  - 2.4
+  - 2.3
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+    - JEKYLL_VERSION="~> 3.8"
+matrix:
+  include:
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 before_install:
 - gem update --system
 - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}" if ENV["JEKYLL_VERSION"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 
 install_if -> { Gem.win_platform? } do
   gem "tzinfo", "~> 1.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,15 @@ build: off
 
 environment:
   NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+  JEKYLL_VERSION: "~> 3.8"
   matrix:
     - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : "~> 3.7.4"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
+    - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
+    - RUBY_FOLDER_VER: "23"
 
 install:
   - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
+  spec.test_files    = spec.files.grep(%r!^spec/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
The plugin doesn't use Ruby 2.4 specific syntax. So, the Ruby version constraint can be relaxed to minimum version testable across the ecosystem: Ruby 2.3

Other changes:
  - Remove superfluous specifications in the gemspec
  - Test with Jekyll 4.0 pre-release