### PR TITLE
 Add media:content tag to support Mailchimp

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -86,7 +86,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
-        <media:content url="{{ post_image | xml_escape }}" medium=”image”>
+        <media:content url="{{ post_image | xml_escape }}" medium="image">
       {% endif %}
     </entry>
   {% endfor %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -86,6 +86,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
+        <media:content url="{{ post_image | xml_escape }}" medium=”image”>
       {% endif %}
     </entry>
   {% endfor %}


### PR DESCRIPTION
To help ensure that MailChimp can view your feed’s images, you can include medium or type information inside the `<media:content>` tag.

Example: `<media:content url=”http://hathaway.edu/example.jpg” medium="image">`