### PR TITLE
Add media:content tag for Mailchimp templating

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -86,7 +86,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
-        <media:content url="{{ post_image | xml_escape }}" medium="image" />
+        <media:content xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" medium="image" />
       {% endif %}
     </entry>
   {% endfor %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -86,6 +86,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
+        <media:content url="{{ post_image | xml_escape }}" medium="image" />
       {% endif %}
     </entry>
   {% endfor %}


### PR DESCRIPTION
Adding a  <media:content /> tag for using Mailchimp email templates.