### PR TITLE
Excerpt only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ feed:
         - updates
 ```
 
+## Excerpt Only flag
+
+Optional flag `excerpt_only` allows you to exclude post content from the Atom feed. Default value is `false` for backward compatibility.
+
+When in `config.yml` is `true` than all posts in feed will be without `<content>` tags.
+
+```yml
+feed:
+  excerpt_only: true
+```
+
+The same flag can be used directly in post file. It will be disable `<content>` tag for selected post.
+Settings in post file has higher priority than in config file.
+
+
 ## Contributing
 
 1. Fork it (https://github.com/jekyll/jekyll-feed/fork)

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,7 +50,7 @@
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only | default: false %}
+      {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only %}
       {% unless excerpt_only %}
         {% assign post_content = post.content %}
       {% endunless %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,7 +50,13 @@
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
+      {% assign excerpt_only = post.excerpt_only | default: site.excerpt_only | default: false %}
+      {% unless excerpt_only %}
+        {% assign post_content = post.content %}
+      {% endunless %}
+      {% if post_content %}
+        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post_content | strip | xml_escape }}</content>
+      {% endif %}
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
       {% assign post_author = site.data.authors[post_author] | default: post_author %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,7 +50,7 @@
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      {% assign excerpt_only = post.excerpt_only | default: site.excerpt_only | default: false %}
+      {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only | default: false %}
       {% unless excerpt_only %}
         {% assign post_content = post.content %}
       {% endunless %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -52,11 +52,8 @@
       <id>{{ post.id | absolute_url | xml_escape }}</id>
       {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only %}
       {% unless excerpt_only %}
-        {% assign post_content = post.content %}
+        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
       {% endunless %}
-      {% if post_content %}
-        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post_content | strip | xml_escape }}</content>
-      {% endif %}
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
       {% assign post_author = site.data.authors[post_author] | default: post_author %}

--- a/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
+++ b/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
@@ -1,5 +1,6 @@
 ---
-excerpt_only: true
+feed:
+  excerpt_only: true
 ---
 
 This content should not be in feed.

--- a/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
+++ b/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
@@ -1,2 +1,5 @@
 ---
+excerpt_only: true
 ---
+
+This content should not be in feed.

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -471,4 +471,36 @@ describe(JekyllFeed) do
       end
     end
   end
+
+  context "excerpt_only flag" do
+    context "backward compatibility for no excerpt_only flag" do
+      it "should be in contents" do
+        expect(contents).to match '<content '
+      end
+    end
+
+    context "when site.excerpt_only flag is true" do
+      let(:overrides) { { "excerpt_only" => true } }
+
+      it "should not set any contents" do
+        expect(contents).to_not match '<content '
+      end
+    end
+
+    context "when site.excerpt_only flag is false" do
+      let(:overrides) { { "excerpt_only" => false } }
+
+      it "should be in contents" do
+        expect(contents).to match '<content '
+      end
+    end
+
+    context "when post.excerpt_only flag is true" do
+      let(:overrides) { { "excerpt_only" => false } }
+
+      it "should not be in contents" do
+        expect(contents).to_not match "This content should not be in feed.</content>"
+      end
+    end
+  end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -480,7 +480,9 @@ describe(JekyllFeed) do
     end
 
     context "when site.excerpt_only flag is true" do
-      let(:overrides) { { "excerpt_only" => true } }
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => true } }
+      end
 
       it "should not set any contents" do
         expect(contents).to_not match '<content '
@@ -488,7 +490,9 @@ describe(JekyllFeed) do
     end
 
     context "when site.excerpt_only flag is false" do
-      let(:overrides) { { "excerpt_only" => false } }
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => false } }
+      end
 
       it "should be in contents" do
         expect(contents).to match '<content '
@@ -496,7 +500,9 @@ describe(JekyllFeed) do
     end
 
     context "when post.excerpt_only flag is true" do
-      let(:overrides) { { "excerpt_only" => false } }
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => false } }
+      end
 
       it "should not be in contents" do
         expect(contents).to_not match "This content should not be in feed.</content>"


### PR DESCRIPTION
Create new flag `excerpt_only`, which allows to exclude post content from feed.

PR to issue: https://github.com/jekyll/jekyll-feed/issues/277

BTW I don't like name `excerpt_only`, but don't have better idea. IMO this name should get true value for full content and false value for excerpt.