### PR TITLE
Add media:content tag

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -7,6 +7,7 @@
 ### Minor Enhancements
 
   * Excerpt only flag (#287)
+  * Add media:content tag
 
 ## 0.12.1 / 2019-03-23
 

--- a/History.markdown
+++ b/History.markdown
@@ -7,7 +7,6 @@
 ### Minor Enhancements
 
   * Excerpt only flag (#287)
-  * Add media:content tag
 
 ## 0.12.1 / 2019-03-23
 

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -89,6 +89,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
+        <media:content medium="image" url="{{ post_image | xml_escape }}" xmlns:media="http://search.yahoo.com/mrss/" />
       {% endif %}
     </entry>
   {% endfor %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -92,10 +92,22 @@ describe(JekyllFeed) do
     expect(contents).not_to match "Liquid is not rendered."
   end
 
-  it "includes the item image" do
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/image.png" />')
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="https://cdn.example.org/absolute.png?h=188&amp;w=250" />')
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/object-image.png" />')
+  context "images" do
+    let(:image1) { 'http://example.org/image.png' }
+    let(:image2) { 'https://cdn.example.org/absolute.png?h=188&amp;w=250' }
+    let(:image3) { 'http://example.org/object-image.png' }
+
+    it "includes the item image" do
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image1}" />))
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image2}" />))
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image3}" />))
+    end
+
+    it "included media content for mail templates (Mailchimp)" do
+      expect(contents).to include(%(<media:content medium="image" url="#{image1}" xmlns:media="http://search.yahoo.com/mrss/" />))
+      expect(contents).to include(%(<media:content medium="image" url="#{image2}" xmlns:media="http://search.yahoo.com/mrss/" />))
+      expect(contents).to include(%(<media:content medium="image" url="#{image3}" xmlns:media="http://search.yahoo.com/mrss/" />))
+    end
   end
 
   context "parsing" do


### PR DESCRIPTION
Add media:content tag which is using by mail templates like Mailchimp.
I decided to finish what started @ladyd252 and @mikepsinn.
Original pull requests:
- Fix https://github.com/jekyll/jekyll-feed/pull/273
- Fix https://github.com/jekyll/jekyll-feed/pull/275

I only corrected what needed to be changed and added tests.

Quote from the [Mailchimp website](https://mailchimp.com/help/rss-merge-tags/):
> To help ensure that Mailchimp can view your feed's images, you can include medium or type information inside the <media:content> tag.