### PR TITLE
XML escape the title field of feed_meta

### DIFF
--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -22,7 +22,7 @@ module JekyllFeed
         :type  => "application/atom+xml",
         :rel   => "alternate",
         :href  => absolute_url(path),
-        :title => title,
+        :title => title&.encode(:xml => :text),
       }.keep_if { |_, v| v }
     end
 

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -7,7 +7,7 @@ module JekyllFeed
 
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(" ")
+      attrs    = attributes.map { |k, v| %(#{k}=#{v.encode(:xml => :attr)}) }.join(" ")
       "<link #{attrs} />"
     end
 
@@ -22,7 +22,7 @@ module JekyllFeed
         :type  => "application/atom+xml",
         :rel   => "alternate",
         :href  => absolute_url(path),
-        :title => title&.encode(:xml => :text),
+        :title => title,
       }.keep_if { |_, v| v }
     end
 

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -207,6 +207,15 @@ describe(JekyllFeed) do
         expect(feed.title.content).to eql(site_title)
       end
     end
+
+    context "with site.title has special characters" do
+      let(:site_title) { "My Site Title <&>" }
+      let(:overrides) { { "title" => site_title } }
+
+      it "uses encoded site.title for the title" do
+        expect(feed.title.content).to eql(site_title.encode(xml: :text))
+      end
+    end
   end
 
   context "smartify" do


### PR DESCRIPTION
When site title has special characters such as `<&>"`, this patch would encode them with xml compatible format(`&lt;&amp;&gt;`)