### PR TITLE
chore(deps): require Ruby >=2.4.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
       JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
     - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
-    - RUBY_FOLDER_VER: "23"
 
 install:
   - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^spec/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 


### PR DESCRIPTION
Align with other core plugins that already require 2.4 
Ruby 2.4 is now EOL.