### PR TITLE
Add support for drafts

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -40,14 +40,17 @@
   {% endif %}
 
   {% if page.tags %}
-    {% assign entries = site.tags[page.tags] %}
+    {% assign posts = site.tags[page.tags] %}
   {% else %}
-    {% assign entries = site[page.collection] %}
+    {% assign posts = site[page.collection] %}
   {% endif %}
-  {% assign posts = entries | where_exp: "post", "post.draft != true" | sort: "date" | reverse %}
   {% if page.category %}
-    {% assign posts = posts | where: "category",page.category %}
+    {% assign posts = posts | where: "category", page.category %}
   {% endif %}
+  {% unless site.show_drafts %}
+    {% assign posts = posts | where_exp: "post", "post.draft != true" %}
+  {% endunless %}
+  {% assign posts = posts | sort: "date" | reverse %}
   {% assign posts_limit = site.feed.posts_limit | default: 10 %}
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -9,7 +9,7 @@ describe(JekyllFeed) do
       "full_rebuild" => true,
       "source"       => source_dir,
       "destination"  => dest_dir,
-      "show_drafts"  => true,
+      "show_drafts"  => false,
       "url"          => "http://example.org",
       "name"         => "My awesome site",
       "author"       => {
@@ -699,6 +699,28 @@ describe(JekyllFeed) do
 
       expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       expect(contents).to match "http://example.org/2016/04/25/author-reference.html"
+    end
+  end
+
+  context "support drafts" do
+    context "with disable show_drafts option" do
+      let(:overrides) do
+        { "show_drafts" => false }
+      end
+
+      it "should not be draft post" do
+        expect(contents).to_not match "a-draft.html"
+      end
+    end
+
+    context "with enable show_drafts option" do
+      let(:overrides) do
+        { "show_drafts" => true }
+      end
+
+      it "should be draft post" do
+        expect(contents).to match "a-draft.html"
+      end
     end
   end
 end


### PR DESCRIPTION
From now, when you run `jekyll serve --drafts`, your RSS feeds will also contain also drafts posts.
The same behavior is in Jekyll Sitemap.