### PR TITLE
Use `relative_url` to generate feed path link.

### DIFF
--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -21,7 +21,7 @@ module JekyllFeed
       {
         :type  => "application/atom+xml",
         :rel   => "alternate",
-        :href  => absolute_url(path),
+        :href  => relative_url(path),
         :title => title,
       }.keep_if { |_, v| v }
     end


### PR DESCRIPTION
Using the relative URL allows the plugin to be used without modification
when generating sites that may be deployed across more than one domain
name without needing to have the site regenerated for each domain name.

This commit also aligns the code with the code's comments (added in
commit bf728c32) which say that the built-in Jekyll URLFilters are being
used to provide the `relative_url` functionality, but then the code goes
on to use the `absolute_url` filter.

Using the `relative_url` filter does not impact feed reader use (at
least, in my testing), so this should be a backward-compatible change
that improves the versatility of the rendered HTML code.