### PR TITLE
MetaTag: when encoding for XML special characters, handle non-string objects

### DIFF
--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -7,8 +7,11 @@ module JekyllFeed
 
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}=#{v.encode(:xml => :attr)}) }.join(" ")
-      "<link #{attrs} />"
+      attrs    = attributes.map do |k, v|
+        v = v.to_s unless v.respond_to?(:encode)
+        %(#{k}=#{v.encode(:xml => :attr)})
+      end
+      "<link #{attrs.join(" ")} />"
     end
 
     private

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -189,6 +189,21 @@ describe(JekyllFeed) do
       end
     end
 
+    context "with site.title set as a non-string value" do
+      class MySiteTitle
+        def to_s
+          "My Dynamic Site Title <&>"
+        end
+        alias_method :to_liquid, :to_s
+      end
+      let(:site_title) { MySiteTitle.new }
+      let(:overrides) { { "title" => site_title } }
+
+      it "ensures the site.title is the string representation of the object" do
+        expect(feed.title.content).to eql(site_title.to_s.encode(xml: :text))
+      end
+    end
+
     context "with site.name set" do
       let(:site_name) { "My Site Name" }
       let(:overrides) { { "name" => site_name } }


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-feed/issues/325.

The jekyll-github-metadata plugin, for example, sets `site.title` and
`site.name` to `Jekyll::GitHubMetadata::Value` objects which respond to
`#to_s` and `#to_liquid`, but NOT `#encode`. Therefore, we should cast
to a string if `#encode` is not yet available.

The reason we cast to a string is because the previous code was
`"#{k}=#{v}"`, which was implicitly casting to a string for `v`.