### PR TITLE
Fold private methods into the `:render` method as local variables

### DIFF
--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -6,15 +6,18 @@ module JekyllFeed
     include Jekyll::Filters::URLFilters
 
     def render(context)
-      @context = context
-      attrs    = attributes.map do |k, v|
-        v = v.to_s unless v.respond_to?(:encode)
-        %(#{k}=#{v.encode(:xml => :attr)})
-      end
-      "<link #{attrs.join(" ")} />"
+      @context ||= context
+      memoized_result
     end
 
     private
+
+    def memoized_result
+      @memoized_result ||= begin
+        attrs = attributes.map { |k, v| "#{k}=#{v.to_s.encode(:xml => :attr)}" }
+        "<link #{attrs.join(" ")} />"
+      end
+    end
 
     def config
       @config ||= @context.registers[:site].config

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -8,30 +8,20 @@ module JekyllFeed
     def render(context)
       # Jekyll::Filters::URLFilters requires `@context` to be set in the environment.
       @context = context
-      xml_encoded_link_tag
-    end
 
-    private
+      config = context.registers[:site].config
+      path   = config.dig("feed", "path") || "feed.xml"
+      title  = config["title"] || config["name"]
 
-    def config
-      @config ||= @context.registers[:site].config
-    end
+      attributes = {
+        :type => "application/atom+xml",
+        :rel  => "alternate",
+        :href => absolute_url(path),
+      }
+      attributes[:title] = title if title
 
-    def xml_encoded_link_tag
-      @xml_encoded_link_tag ||= begin
-        path  = config.dig("feed", "path") || "feed.xml"
-        title = config["title"] || config["name"]
-
-        attributes = {
-          :type => "application/atom+xml",
-          :rel  => "alternate",
-          :href => absolute_url(path),
-        }
-        attributes[:title] = title if title
-
-        attrs = attributes.map { |k, v| "#{k}=#{v.to_s.encode(:xml => :attr)}" }.join(" ")
-        "<link #{attrs} />"
-      end
+      attrs = attributes.map { |k, v| "#{k}=#{v.to_s.encode(:xml => :attr)}" }.join(" ")
+      "<link #{attrs} />"
     end
   end
 end


### PR DESCRIPTION
Since the meta tag contents doesn't depend on *page-specific* metadata, the resulting markup is essentially the same for all pages / documents in a site:
https://github.com/jekyll/jekyll-feed/blob/653999c975564e30003d2c0c247d59e5a89eecda/lib/jekyll-feed/meta-tag.rb#L23-L38

Therefore in theory, the result can be safely memoized to avoid generating arrays for every page / document..