### PR TITLE
Add Ruby 3.0 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: ruby
 cache: bundler
 rvm:
-  - &latest_ruby 2.7
+  - 3.0
+  - 2.7
   - 2.5
 env:
   matrix:
     - JEKYLL_VERSION="~> 3.9"
+    - JEKYLL_VERSION="~> 4.2"
 matrix:
-  include:
-    - rvm: *latest_ruby
-      env: JEKYLL_VERSION="~> 3.9"
-    - rvm: *latest_ruby
+  exclude:
+    - rvm: 2.5
       env: JEKYLL_VERSION="~> 4.2"
 before_install:
 - gem update --system

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rss" if RUBY_VERSION >= '3.0.0'
   spec.add_development_dependency "rubocop-jekyll", "~> 0.5"
   spec.add_development_dependency "typhoeus", ">= 0.7", "< 2.0"
 end

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rss" if RUBY_VERSION >= '3.0.0'
   spec.add_development_dependency "rubocop-jekyll", "~> 0.5"
   spec.add_development_dependency "typhoeus", ">= 0.7", "< 2.0"
 end


### PR DESCRIPTION
jekyll-feed will be [included in Fedora 34][pkg] which will also use [Ruby 3.0
as system Ruby interpreter][ruby]. This combination is known to work, so it
would make sense to add it to CI.

[pkg]: https://src.fedoraproject.org/rpms/rubygem-jekyll-feed
[ruby]: https://fedoraproject.org/wiki/Changes/Ruby_3.0