### PR TITLE
Add workflow to release gem via GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release Gem
+
+on:
+  push:
+    branches: ["master"]
+    paths: ["lib/**/version.rb"]
+
+jobs:
+  release:
+    if: "github.repository_owner == 'jekyll'"
+    name: "Release Gem (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby_version: ["2.7"]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Build and Publish Gem
+        uses: ashmaroli/release-gem@dist
+        with:
+          gemspec_name: "jekyll-feed"
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_GEM_PUSH_API_KEY }}


### PR DESCRIPTION
Set up GH Action to release a new version if `lib/jekyll-feed/version.rb` is changed and pushed to the `master` branch. 