### PR TITLE
Use .atom extension in docs examples since we write an Atom feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Do you already have an existing feed someplace other than `/feed.xml`, but are o
 
 ```yml
 feed:
-  path: atom.xml
+  path: /blog/feed.atom
 ```
 
 To note, you shouldn't have to do this unless you already have a feed you're using, and you can't or wish not to redirect existing subscribers.
@@ -178,7 +178,7 @@ By default, collection feeds will be outputted to `/feed/<COLLECTION>.xml`. If y
 feed:
   collections:
     changes:
-      path: "/changes.xml"
+      path: "/changes.atom"
 ```
 
 Finally, collections can also have category feeds which are outputted as `/feed/<COLLECTION>/<CATEGORY>.xml`. Specify categories like so:
@@ -187,7 +187,7 @@ Finally, collections can also have category feeds which are outputted as `/feed/
 feed:
   collections:
     changes:
-      path: "/changes.xml"
+      path: "/changes.atom"
       categories:
         - news
         - updates


### PR DESCRIPTION
Using `.atom` also will use the correct MIME type, `application/atom+xml` (https://github.com/jekyll/jekyll-feed/issues/358).

We **cannot** update the default paths to write `.atom` since that would break existing sites (only solution would be to double-write the `.xml` and `.atom` files) so I only updated the `feed.path` configuration where applicable since folks generally copy-paste that kind of thing so this would at least convert some new sites to use `.atom`.