### PR TITLE
Generate posts feed by custom sorting method

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ feed:
   posts_limit: 20
 ```
 
+### Posts sort
+
+By default, posts will be sorted by `date` in the feed. Simply define a new sorting method in your config: 
+
+```yml
+feed:
+  posts_sort: last_modified_at
+```
+
 ## Collections
 
 Jekyll Feed can generate feeds for collections other than the Posts collection. This works best for chronological collections (e.g., collections with dates in the filenames). Simply define which collections you'd like feeds for in your config:

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,7 +50,8 @@
   {% unless site.show_drafts %}
     {% assign posts = posts | where_exp: "post", "post.draft != true" %}
   {% endunless %}
-  {% assign posts = posts | sort: "date" | reverse %}
+  {% assign posts_sort = site.feed.posts_sort | default: "date" %}
+  {% assign posts = posts | sort: posts_sort | reverse %}
   {% assign posts_limit = site.feed.posts_limit | default: 10 %}
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>


### PR DESCRIPTION
By default, posts will be sorted by `date` in the feed. Simply define a new sorting method in your config such as `posts_sort: last_modified_at`.