### PR TITLE
Upgrade to Rake 13 to fix master

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "nokogiri", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.12.0"
   spec.add_development_dependency "typhoeus", ">= 0.7", "< 2.0"


### PR DESCRIPTION
I had a CI run fail for #379 which looks like a failure in the "setup ruby" step.

I'm not sure how the changes I made in #379 could have caused that problem—it fails even before attempting to run the tests, and I haven't touched anything related to dependencies.

I'm trying to figure out whether my intuition is incorrect, or whether CI is actually failing on master. I notice that the last master change was from a couple months ago, so I'm worried that some dependency has broken in the mean time.