### PR TITLE
Added unless statement to avoid duplicate <category> elements.

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -91,7 +91,9 @@
       {% endif %}
 
       {% for tag in post.tags %}
-        <category term="{{ tag | xml_escape }}" />
+        {% unless post.categories contains tag %}      
+          <category term="{{ tag | xml_escape }}" />
+        {% endunless %}
       {% endfor %}
 
       {% assign post_summary = post.description | default: post.excerpt %}


### PR DESCRIPTION
Added an unless statement to avoid duplicate <category> elements if a site tag is the same as a site category.

This is related to issue #383.