### PR TITLE
Escape any stray CDATA end tokens that may be in the post contents

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -52,6 +52,8 @@
   {% endunless %}
   {% assign posts = posts | sort: "date" | reverse %}
   {% assign posts_limit = site.feed.posts_limit | default: 10 %}
+  {% assign cdata_end_token = "]]>" %}
+  {% assign cdata_end_token_escaped = "]]]]><![CDATA[>" %}
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       {% assign post_title = post.title | smartify | strip_html | normalize_whitespace | xml_escape %}
@@ -63,7 +65,7 @@
       <id>{{ post.id | absolute_url | xml_escape }}</id>
       {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only %}
       {% unless excerpt_only %}
-        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}"><![CDATA[{{ post.content | strip }}]]></content>
+        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}"><![CDATA[{{ post.content | strip | replace: cdata_end_token, cdata_end_token_escaped }}]]></content>
       {% endunless %}
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
@@ -96,7 +98,7 @@
 
       {% assign post_summary = post.description | default: post.excerpt %}
       {% if post_summary and post_summary != empty %}
-        <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace }}]]></summary>
+        <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace | replace: cdata_end_token, cdata_end_token_escaped }}]]></summary>
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}

--- a/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
+++ b/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
@@ -8,4 +8,4 @@ image:
 categories: updates jekyll
 ---
 
-March the fourth!
+<!-- ]]> -->March the fourth!


### PR DESCRIPTION
## Description

Normally you wouldn't have any CDATA end tokens `]]>` in post content, because `>` gets converted to `&gt;`.

However, in certain circumstances, like HTML comments, one can slip through the markdown parser unescaped. This totally breaks the XML, and the only way around it is to escape the end token.

[The only real way to escape CDATA end tokens is to split them up.](https://stackoverflow.com/questions/223652/is-there-a-way-to-escape-a-cdata-end-token-in-xml) I.e. instead of having a single string `]]>`, we instead have `]]` *(end CDATA)* *(start another CDATA)* `>`. The two adjacent CDATAs will then be concatenated. 

That looks like this messy string: `]]]]><![CDATA[>`. The first `]]` is the first part of the split token, the following `]]>` ends the CDATA, `<![CDATA[` starts another one, and the final `>` is the second part of the split token.

This pull request does the following:

1. Escapes any `]]>` strings in both post content and summary in the feed.xml as described above
2. Adds a test case in rspec over this, adding it to the "March the Fourth" post in spec/fixtures. 

## Test plan

Before the feed.xml changes (but with the test case in place):

```
jekyll-feed $ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 53922
.....................F................................................

Failures:

  1) JekyllFeed validation validates
     Failure/Error: expect(result.css("validity").text).to eql("true"), errors.join("\n")
     
       Validation error: Undefined content element: p on line 4 column 0
       Validation error: XML parsing error: <unknown>:4:26: not well-formed (invalid token) on line 4 column 26
     # ./spec/jekyll-feed_spec.rb:280:in `block (3 levels) in <top (required)>'

Finished in 3.04 seconds (files took 0.60692 seconds to load)
70 examples, 1 failure

Failed examples:

rspec ./spec/jekyll-feed_spec.rb:254 # JekyllFeed validation validates
```

After the feed.xml changes:

```
jekyll-feed $ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 46246
......................................................................

Finished in 3.09 seconds (files took 0.61881 seconds to load)
70 examples, 0 failures
```