### PR TITLE
Add "html_excerpts" flag to allow Atom <summary> tags to contain HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,16 +207,16 @@ feed:
 The same flag can be used directly in post file. It will disable `<content>` tag for selected post.
 Settings in post file have higher priority than in config file.
 
-## HTML Summaries flag
+## HTML Excerpts flag
 
-By default, the `<summary>` portion of the feed—containing the post's excerpt or description—will be stripped of all HTML, and will have all its whitespace normalized. The optional flag `html_summaries` turns that behaviour off, allowing your excerpts to contain full HTML content.
+By default, the `<summary>` portion of the feed—containing the post's excerpt or description—will be stripped of all HTML, and will have all its whitespace normalized. The optional flag `html_excerpts` turns that behaviour off, allowing your excerpts to contain full HTML content.
 
 ```yml
 feed:
-  html_summaries: true
+  html_excerpts: true
 ```
 
-This is useful in feeds where the summaries have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to fall back to [using the first paragraph of the post as the excerpt](https://jekyllrb.com/docs/posts/#post-excerpts).
+This is useful in feeds where the summaries have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to [use the entire first paragraph of the post as the excerpt](https://jekyllrb.com/docs/posts/#post-excerpts).
 
 ## Tags
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ feed:
 The same flag can be used directly in post file. It will disable `<content>` tag for selected post.
 Settings in post file have higher priority than in config file.
 
+## HTML Summaries flag
+
+By default, the `<summary>` portion of the feed—containing the post's excerpt or description—will be stripped of all HTML, and will have all its whitespace normalized. The optional flag `html_summaries` turns that behaviour off, allowing your excerpts to contain full HTML content.
+
+```yml
+feed:
+  html_summaries: true
+```
+
+This is useful in feeds where the summaries have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to fall back to [using the first paragraph of the post as the excerpt](https://jekyllrb.com/docs/posts/#post-excerpts).
+
 ## Tags
 
 To automatically generate feeds for each tag you apply to your posts you can add a tags setting to your config:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ feed:
   html_excerpts: true
 ```
 
-This is useful in feeds where the summaries have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to [use the entire first paragraph of the post as the excerpt](https://jekyllrb.com/docs/posts/#post-excerpts).
+This is useful in feeds where the excerpts have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to [use the entire first paragraph of the post as the excerpt](https://jekyllrb.com/docs/posts/#post-excerpts).
 
 ## Tags
 

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -96,7 +96,7 @@
 
       {% assign post_summary = post.description | default: post.excerpt %}
       {% if post_summary and post_summary != empty %}
-        {% if site.feed.html_summaries %}
+        {% if site.feed.html_excerpts %}
           <summary type="html"><![CDATA[{{ post_summary | strip }}]]></summary>
         {% else %}
           <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace }}]]></summary>

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -96,7 +96,11 @@
 
       {% assign post_summary = post.description | default: post.excerpt %}
       {% if post_summary and post_summary != empty %}
-        <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace }}]]></summary>
+        {% if site.feed.html_summaries %}
+          <summary type="html"><![CDATA[{{ post_summary | strip }}]]></summary>
+        {% else %}
+          <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace }}]]></summary>
+        {% endif %}
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -172,8 +172,8 @@ describe(JekyllFeed) do
       expect(post.summary.content).to_not match "\n"
     end
 
-    context "with feed.html_summaries set" do
-      let(:overrides) { { "feed" => { "html_summaries" => true } } }
+    context "with feed.html_excerpts set" do
+      let(:overrides) { { "feed" => { "html_excerpts" => true } } }
 
       it "doesn't strip HTML in summaries" do
         post = feed.items[3] # The "pre" file

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -162,6 +162,11 @@ describe(JekyllFeed) do
       expect(post.summary).to be_nil
     end
 
+    it "strips HTML in summaries by default" do
+      post = feed.items[3] # The "pre" file
+      expect(post.summary.content).to_not match "<pre>"
+    end
+
     context "with site.lang set" do
       lang = "en_US"
       let(:overrides) { { "lang" => lang } }

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -172,6 +172,20 @@ describe(JekyllFeed) do
       expect(post.summary.content).to_not match "\n"
     end
 
+    context "with feed.html_summaries set" do
+      let(:overrides) { { "feed" => { "html_summaries" => true } } }
+
+      it "doesn't strip HTML in summaries" do
+        post = feed.items[3] # The "pre" file
+        expect(post.summary.content).to match "<pre>"
+      end
+
+      it "doesn't normalize whitespace in summaries" do
+        post = feed.items[3] # The "pre" file
+        expect(post.summary.content).to match "\n"
+      end
+    end
+
     context "with site.lang set" do
       lang = "en_US"
       let(:overrides) { { "lang" => lang } }

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -167,6 +167,11 @@ describe(JekyllFeed) do
       expect(post.summary.content).to_not match "<pre>"
     end
 
+    it "normalizes whitespace in summaries by default" do
+      post = feed.items[3] # The "pre" file
+      expect(post.summary.content).to_not match "\n"
+    end
+
     context "with site.lang set" do
       lang = "en_US"
       let(:overrides) { { "lang" => lang } }


### PR DESCRIPTION
This option should be useful in feeds where the summaries have more complex content or formatting, such as when the post's `description` and `excerpt` front matter options are not set, causing Jekyll to [use the entire first paragraph of the post as the excerpt][0].

It pairs really well with `excerpts_only` for sites which may not want to put the entirety of each post's content in the feed, but who want to preserve the excerpt's rich formatting and content. 

In [my site][1], for example, post excerpts often have images. Its feed currently contains the entire post content, but I'm considering switching it to `excerpts_only`, and I'd very much prefer keeping those images intact in the feed if I do switch.

Note that this passes the W3C validator with no warnings, since feed.xml already uses `type="html"` in its `<summary>` tags. And since it's an option, and not a change in the default behaviour, it shouldn't break existing content.

This PR also comes complete with tests and documentation!

[0]: https://jekyllrb.com/docs/posts/#post-excerpts
[1]: https://www.kronopath.com/blog/