### PR TITLE
Icon and logo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ The plugin will automatically use any of the following configuration variables, 
 * `description` - A longer description of what your site is about, e.g., "Where I blog about Jekyll and other awesome things"
 * `url` - The URL to your site, e.g., `https://example.com`. If none is provided, the plugin will try to use `site.github.url`.
 * `author` - Global author information (see below)
+* `blog.icon` - Icon with 1:1 proportions for readers to use for the blog (not supported by all readers; often overridden by a favicon or site icon)
+* `blog.logo` - Logo with 2:1 proportions for readers to use for the blog (not supported by all readers). 
+  For example, both of the preceding can be expressed:
+  ```yml
+  blog:
+    icon: /images/icon.png
+    logo: /images/logo.png
+  ```
+
 
 ### Already have a feed path?
 

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -27,12 +27,20 @@
     <subtitle>{{ site.description | xml_escape }}</subtitle>
   {% endif %}
 
-  {% if site.blog_icon %}
-    {% assign blog_icon = site.blog_icon %}
+  {% if site.blog.icon %}
+    {% assign blog_icon = site.blog.icon %}
     {% unless blog_icon contains "://" %}
       {% assign blog_icon = blog_icon | absolute_url %}
     {% endunless %}
     <icon>{{ blog_icon | xml_escape }}</icon>
+  {% endif %}
+
+  {% if site.blog.logo %}
+    {% assign blog_logo = site.blog.logo %}
+    {% unless blog_logo contains "://" %}
+      {% assign blog_logo = blog_logo | absolute_url %}
+    {% endunless %}
+    <logo>{{ blog_logo | xml_escape }}</logo>
   {% endif %}
 
   {% if site.author %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -27,6 +27,14 @@
     <subtitle>{{ site.description | xml_escape }}</subtitle>
   {% endif %}
 
+  {% if site.blog_icon %}
+    {% assign blog_icon = site.blog_icon %}
+    {% unless blog_icon contains "://" %}
+      {% assign blog_icon = blog_icon | absolute_url %}
+    {% endunless %}
+    <icon>{{ blog_icon | xml_escape }}</icon>
+  {% endif %}
+
   {% if site.author %}
     <author>
         <name>{{ site.author.name | default: site.author | xml_escape }}</name>


### PR DESCRIPTION
A patch to support a blog icon and logo via the _config.yml file. Many feed readers will default to using a site's favicon or icon resources, but the Atom spec supports both an icon (square, so with 1:1 proportions) and a logo (2:1 proportions), so this adds them in. I did this with a more generalizable addition to the xml file:

```yml
blog:
  icon: path/image.png
  logo: path/image2.png
```

In theory other blog properties could be added here. Another way to do it would be the way jekyll already allows a blog title via a `blog_title` entry in the config file, so with `blog_icon` and `blog_logo`, but I think this way is cleaner.