### PR TITLE
Hub Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,15 @@ feed:
   disable_in_development: true
 ```
 
+## Hub
+
+To set a Hub in your feed, simply define set the following in your config:
+
+```yml
+feed:
+  hub: https://your-hub-here.com
+```
+
 ## Contributing
 
 1. Fork it (https://github.com/jekyll/jekyll-feed/fork)

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -6,6 +6,7 @@
   <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
   <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
   <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" {% if site.lang %}hreflang="{{ site.lang }}" {% endif %}/>
+  {% if site.feed.hub %}<link rel="hub" href="{{site.feed.hub}}" />{% endif %}  
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ page.url | absolute_url | xml_escape }}</id>
 

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -747,6 +747,16 @@ describe(JekyllFeed) do
       end
     end
   end
+  context "with hub option" do
+    let(:overrides) do
+      { "feed" => { "hub" => "https://hub.com" } }
+    end
+
+    it "inserts the hub url in the feed.xml file" do
+      expect(contents).to match "https://hub.com"
+    end
+  end
+
 
   context "with skip_development" do
     let(:overrides) do


### PR DESCRIPTION
Adds the `rel=hub` tag to the feed, allowing sites to integrate with WebSub hubs.

The desired Hub can be specified as in the config as:

```yml
feed:
  hub: https://your-hub-here.com
```

If not set, no Hub is included. 