### PR TITLE
Filter out hidden posts

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,6 +50,7 @@
   {% unless site.show_drafts %}
     {% assign posts = posts | where_exp: "post", "post.draft != true" %}
   {% endunless %}
+  {% assign posts = posts | where_exp: "post", "post.hidden != true" %}
   {% assign posts = posts | sort: "date" | reverse %}
   {% assign posts_limit = site.feed.posts_limit | default: 10 %}
   {% for post in posts limit: posts_limit %}

--- a/spec/fixtures/_posts/2024-01-31-hidden-sample.md
+++ b/spec/fixtures/_posts/2024-01-31-hidden-sample.md
@@ -1,0 +1,5 @@
+---
+hidden: true
+---
+
+# A hidden post

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -50,6 +50,7 @@ describe(JekyllFeed) do
     expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
     expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
     expect(contents).to_not match "http://example.org/2016/02/09/a-draft.html"
+    expect(contents).to_not match "http://example.org/2024/01/31/hidden-sample.html"
   end
 
   it "does not include assets or any static files that aren't .html" do
@@ -411,6 +412,7 @@ describe(JekyllFeed) do
         expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
         expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
         expect(contents).to_not match "http://example.org/2016/02/09/a-draft.html"
+        expect(contents).to_not match "http://example.org/2024/01/31/hidden-sample.html"
       end
 
       it "outputs the category feeds" do
@@ -443,6 +445,7 @@ describe(JekyllFeed) do
         expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
         expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
         expect(contents).to_not match "http://example.org/2016/02/09/a-draft.html"
+        expect(contents).to_not match "http://example.org/2024/01/31/hidden-sample.html"
       end
 
       it "outputs the category feed" do


### PR DESCRIPTION

Jekyll doesn't list the posts with a front matter variable `hidden: true` or `hidden: 1` in the paginator / posts listing page.

This change applies the same behavior to the generated feed.